### PR TITLE
Sys 751/project form

### DIFF
--- a/dlcs_staff_ui/urls.py
+++ b/dlcs_staff_ui/urls.py
@@ -15,7 +15,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.conf.urls import include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('oral_history.urls')),
 ]

--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import Projects
+
+class ProjectsForm(forms.ModelForm):
+
+    class Meta:
+        model = Projects
+        exclude = ['projectid_pk']

--- a/oral_history/templates/oral_history/base.html
+++ b/oral_history/templates/oral_history/base.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/oral_history/templates/oral_history/project.html
+++ b/oral_history/templates/oral_history/project.html
@@ -1,0 +1,9 @@
+{% extends 'oral_history/base.html' %}
+
+{% block content %}
+<form method="POST">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/oral_history/urls.py
+++ b/oral_history/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('projects/new', views.projects_new, name='projects_new'),
+]

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -1,3 +1,6 @@
 from django.shortcuts import render
+from .forms import ProjectsForm
 
-# Create your views here.
+def projects_new(request):
+    form = ProjectsForm()
+    return render(request, 'oral_history/project.html', {'form': form})


### PR DESCRIPTION
Added scaffolding for blank Projects form. This does not save yet, and may be tested by navigating to:
`/projects/new`
A blank form with all fields in the Projects model should be displayed, except the field for primary key