### PR TITLE
SYS-784: Install derivative processing programs and python wrappers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM python:3.9-slim-bullseye
 
+# Debian repository management
+RUN apt-get update && apt-get install -y software-properties-common \
+    && apt-add-repository non-free && apt-get update
+
 # Install Oracle client; thanks to https://stackoverflow.com/a/59869379
 WORKDIR /opt/oracle
-RUN apt-get update && apt-get install -y libaio1 wget unzip \
+RUN apt-get install -y libaio1 wget unzip \
     && wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip \
     && unzip instantclient-basiclite-linuxx64.zip \
     && rm -f instantclient-basiclite-linuxx64.zip \
@@ -10,6 +14,10 @@ RUN apt-get update && apt-get install -y libaio1 wget unzip \
     && rm -f *jdbc* *occi* *mysql* *README *jar uidrvci genezi adrci \
     && echo /opt/oracle/instantclient* > /etc/ld.so.conf.d/oracle-instantclient.conf \
     && ldconfig
+
+# Install derivative processing programs from repo,
+# along with java, which jhove requires but the package doesn't install?
+RUN apt-get install -y default-jdk ffmpeg imagemagick jhove
 
 # Create django user and switch context to that user
 RUN useradd -c "django app user" -d /home/django -s /bin/bash -m django

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Django == 4.0.1
-cx_Oracle
+cx_Oracle == 8.3.0
+ffmpeg-python == 0.2.0
+# Wrapper for imagemagick
+wand == 0.6.7


### PR DESCRIPTION
This PR adds 3 programs for processing derivatives, all from Debian 11 (Bullsye) repos:
* ffmpeg 4.3.3-0
* imagemagick 6.9.11-60 Q16
* jhove 1.20.0

For imagemagick, note that there is no **_magick_** command via the official package, but the individual commands like **_convert_** and **_conjure_** are available.

This also adds openjdk 11.0.14 - java is needed by jhove.

Finally, it adds python wrappers for ffmpeg and imagemagick (nothing relevant found for jhove):
* [ffmpeg-python](https://github.com/kkroening/ffmpeg-python)
* [wand](https://docs.wand-py.org/en/0.6.7/) for imagemagick

If different versions or wrappers are needed, please let me know.
