### PR TITLE
SYS-780 - Create Django page which provides test data for file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,21 @@ DJANGO_DB_DSN=host.docker.internal:1599/remote_oracle_service_name
 DJANGO_DB_USER=remote_username
 DJANGO_DB_PASS=remote_password
 ```
+
+### Application operation
+
+This application is intended to be run from the legacy DLCS application where pressing a button will send the primary key (PK) of the selected item to this Django application which, in turn, will pop up a window from which the associated media file location which then may be picked by the user. After file selection, the ARK and media file name are sent to the script which processes the media file into derivatives which are moved to the proper location(s).
+
+Pressing the button on the legacy DLCS app will initate a request something like this:
+
+```
+<a href="https://www;library.ucla.edu/DigitalLibrary/OralHistory/upload_file?divid_pk=[insert the primary key]">Upload the file for this item</a>
+```
+
+A Django page is included that allows simulatation of the button press on the DLCS legacy application with links. This temporary _Harness_ is populated with example data to allow testing of the application and is available in the local environment at:
+
+    - http://127.0.0.1:8000/table
+
+The Admin section is at the standard:
+    - URL: http://127.0.0.1:8000/admin
+

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ This application is intended to be run from the legacy DLCS application where pr
 Pressing the button on the legacy DLCS app will initate a request something like this:
 
 ```
-<a href="https://www;library.ucla.edu/DigitalLibrary/OralHistory/upload_file?divid_pk=[insert the primary key]">Upload the file for this item</a>
+<a href="url_for_this_application/upload_file?divid_pk=[insert the primary key]">Upload the file for this item</a>
 ```
 
 A Django page is included that allows simulatation of the button press on the DLCS legacy application with links. This temporary _Harness_ is populated with example data to allow testing of the application and is available in the local environment at:
 
-    - http://127.0.0.1:8000/table
+    - http://127.0.0.1:8000/projects/table
 
 The Admin section is at the standard:
     - URL: http://127.0.0.1:8000/admin

--- a/oral_history/admin.py
+++ b/oral_history/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from oral_history.models import ProjectItems
 
 # create page to display units
 

--- a/oral_history/admin.py
+++ b/oral_history/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
+# create page to display units
+
+
+@admin.register(ProjectItems)
+class ProjectItemsAdmin(admin.ModelAdmin):
+    list_display = ('divid_pk', 'objectid_fk', 'create_date', 'last_edit_date', 'projectid_fk', 'item_ark', 'sent_to_dpr_flag', 'parent_divid',
+                    'item_sequence', 'old_divid', 'old_parent_divid', 'node_title', 'statusid_fk', 'created_by', 'modified_by', 'approved_by')
+    search_fields = ('created_by', 'modified_by')

--- a/oral_history/templates/oral_history/table.html
+++ b/oral_history/templates/oral_history/table.html
@@ -23,7 +23,7 @@ Sample item record(s) from the database<br>
     </tr>
     {% for item in query_results %}
     <tr> 
-        <td><a href="https://www.ucla.edu?var1=1%var2=2%var3=">{{ item.divid_pk }}</a></td>
+        <td><a href="upload_file?divid_pk={{ item.divid_pk }}">{{ item.divid_pk }}</a></td>
         <td>{{ item.create_date }}</td>
         <td>{{ item.last_edit_date }}</td>
         <td>{{ item.item_ark }}</td>

--- a/oral_history/templates/oral_history/table.html
+++ b/oral_history/templates/oral_history/table.html
@@ -1,0 +1,43 @@
+{% extends 'oral_history/base.html' %}
+
+{% block content %}
+Sample item record(s) from the database<br>
+<br>
+<br>
+<table>
+    <tr>
+        <th>divid_pk</th>
+        <th>create</th>
+        <th>last_edit</th>
+        <th>ark</th>
+        <th>dpr_flag</th>
+        <th>parent_divid</th>
+        <th>item_seq</th>
+        <th>desc_clob</th>
+        <th>old_divid</th>
+        <th>old_parent_divid</th>
+        <th>node_title</th>
+        <th>created_by</th>
+        <th>modified_by</th>
+        <th>approved_by</th>
+    </tr>
+    {% for item in query_results %}
+    <tr> 
+        <td><a href="https://www.ucla.edu?var1=1%var2=2%var3=">{{ item.divid_pk }}</a></td>
+        <td>{{ item.create_date }}</td>
+        <td>{{ item.last_edit_date }}</td>
+        <td>{{ item.item_ark }}</td>
+        <td>{{ item.sent_to_dpr_flag }}</td>
+        <td>{{ item.parent_divid }}</td>
+        <td>{{ item.item_sequence }}</td>
+        <td>...</td>
+        <td>{{ item.old_divid }}</td>
+        <td>{{ item.old_parent_divid }}</td>
+        <td>{{ item.node_title }}</td>
+        <td>{{ item.created_by }}</td>
+        <td>{{ item.modified_by }}</td>
+        <td>{{ item.approved_by }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/oral_history/urls.py
+++ b/oral_history/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('projects/new', views.projects_new, name='projects_new'),
+    path('projects/table', views.projects_table, name='projects_table'),
 ]

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -1,6 +1,13 @@
 from django.shortcuts import render
 from .forms import ProjectsForm
+from .models import ProjectItems
+
 
 def projects_new(request):
     form = ProjectsForm()
     return render(request, 'oral_history/project.html', {'form': form})
+
+
+def projects_table(request):
+    query_results = ProjectItems.objects.all()
+    return render(request, 'oral_history/table.html', {'query_results': query_results})


### PR DESCRIPTION
Connected to [SYS-780](https://jira.library.ucla.edu/browse/SYS-780)

A _Harness_ page was added with a link to the forthcoming page of SYS-781.

---
This is a temporary page used to call the Oral History media processing script. It passes the selected item's ARK to another Django page from which the associated media file may be selected and sent to the OH script.

- [x] A page in the Django app displays sample item record(s) from the database
- [x] For each item, a link appears which includes the necessary data for the file processing script
- [x] See https://docs.library.ucla.edu/x/5xhWE for more details


**Typical Screenshots**
![image](https://user-images.githubusercontent.com/2350153/164518694-33b01d4a-37fa-4d82-a3ef-136ed258ae8f.png)
-----

**Changed Files**
```
oral_history/
    templates/oral_history/
        table.html
    admin.py
    urls.py
    views.py
README.md
```