### PR TITLE
SYS-785 - Display information once processing has finished

### DIFF
--- a/oral_history/management/commands/run_script.py
+++ b/oral_history/management/commands/run_script.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from oral_history.scripts.process import Process
 
 
@@ -27,5 +27,5 @@ class Command(BaseCommand):
             process = Process("reports")
             process.run(file_group_str, file_name_str, item_ark_str)
             return
-        except ValueError as e:
-            exit(e)
+        except CommandError as e:
+            print("Error from script: " + str(e))

--- a/oral_history/scripts/process.py
+++ b/oral_history/scripts/process.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from django.core.management.base import CommandError
+
 
 class Process():
 
@@ -8,3 +10,8 @@ class Process():
 
     def run(self, file_group, file_name, item_ark):
         print(f"script('{file_group}', '{file_name}', '{item_ark}')")
+
+        # error detection goes here
+        # temporary example error, uncomment to view in console
+
+        # raise CommandError('file "%s" not found' % file_name)


### PR DESCRIPTION
Connected to [SYS-785](https://jira.library.ucla.edu/browse/SYS-785)

Messages related to success/failure of the media file processing script need to be made available in the Django environment. In a follow-on ticket, [SYS-805](https://jira.library.ucla.edu/browse/SYS-805), the message will be displayed in the same window that initiated the file upload request using the Django messaging framework. File information about the uploaded file is sent from the media processing script.

-----
**Acceptance criteria:**

- [x] Success / failure information returned by the Django management command is retrieved by the Django application
- [x] Information about the uploaded / processed file also shows (size, location, etc)

-----
**Typical Screenshots**

![image](https://user-images.githubusercontent.com/2350153/165596666-ed648207-d493-4331-bf3a-89632e115f5e.png)

-----
**Changed Files**
```
oral_history/
    management/
        commands/
            run_script.py
    scripts/
        process.py
```