### PR TITLE
SYS-807: Add github action script to build/push to Docker Hub

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -1,0 +1,28 @@
+name: Build for Docker Hub DLCS Staff UI
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build_for_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: uclalibrary/dlcs-staff-ui:latest


### PR DESCRIPTION
This PR adds a GitHub Action script to build/push the Django image to Docker Hub.
It's intended to run only on merge to the `main` branch, and the GH repo has been configured to require approved pull requests before such a merge can happen.