### PR TITLE
SYS-805 - Implement the django messaging framework to display status or error messages

### DIFF
--- a/dlcs_staff_ui/settings.py
+++ b/dlcs_staff_ui/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.0/ref/settings/
 """
+from django.contrib.messages import constants as messages
 import os
 from pathlib import Path
 
@@ -154,4 +155,12 @@ LOGGING = {
             'level': os.getenv('DJANGO_LOG_LEVEL'),
         },
     },
+}
+
+MESSAGE_TAGS = {
+    messages.DEBUG: 'alert-secondary',
+    messages.INFO: 'alert-info',
+    messages.SUCCESS: 'alert-success',
+    messages.WARNING: 'alert-warning',
+    messages.ERROR: 'alert-danger',
 }

--- a/oral_history/management/commands/run_script.py
+++ b/oral_history/management/commands/run_script.py
@@ -23,9 +23,7 @@ class Command(BaseCommand):
         item_ark_str = ''.join(map(str, item_ark))
 
         #
-        try:
-            process = Process("reports")
-            process.run(file_group_str, file_name_str, item_ark_str)
-            return
-        except CommandError as e:
-            print("Error from script: " + str(e))
+
+        process = Process("reports")
+        process.run(file_group_str, file_name_str, item_ark_str)
+        return

--- a/oral_history/scripts/process.py
+++ b/oral_history/scripts/process.py
@@ -12,6 +12,10 @@ class Process():
         print(f"script('{file_group}', '{file_name}', '{item_ark}')")
 
         # error detection goes here
-        # temporary example error, uncomment to view in console
+        # temporary example errors, uncomment to view in console
 
-        # raise CommandError('file "%s" not found' % file_name)
+        #x = 1/0
+
+        #raise CommandError(f'Error from script - File not found: "{file_name}"')
+        # raise CommandError(
+        #    f'Error from script - This ARK format not supported: "{item_ark}"')

--- a/oral_history/scripts/process.py
+++ b/oral_history/scripts/process.py
@@ -12,10 +12,12 @@ class Process():
         print(f"script('{file_group}', '{file_name}', '{item_ark}')")
 
         # error detection goes here
-        # temporary example errors, uncomment to view in console
-
+        #
+        # temporary example errors, uncomment to view in console; replace with the script being written by KristianA
+        #
         #x = 1/0
-
-        #raise CommandError(f'Error from script - File not found: "{file_name}"')
+        #
+        # raise CommandError(
+        #    f'Error from script - File not found: "{file_name}"')
         # raise CommandError(
         #    f'Error from script - This ARK format not supported: "{item_ark}"')

--- a/oral_history/templates/oral_history/base.html
+++ b/oral_history/templates/oral_history/base.html
@@ -4,6 +4,11 @@
     <head>
         <!-- Custom JS -->
         <script src="{% static 'js/main.js' %}" defer></script>
+
+        <!-- Include jquery and bootstrap - use versions compatible with each other -->
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
     </head>
     <body>
         {% block content %}

--- a/oral_history/templates/oral_history/fileupload.html
+++ b/oral_history/templates/oral_history/fileupload.html
@@ -8,6 +8,13 @@ Upload main media file for this item:<br>
 created_by: {{ item.created_by }}<br>
 item_ark: {{ item.item_ark }}<br>
 {% endfor %}
+{% if messages %}
+<ul class = "messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class = "{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+{% endif %}
 <br>
 <form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="skip_upload(this);">
     {% csrf_token %}

--- a/oral_history/templates/oral_history/fileupload.html
+++ b/oral_history/templates/oral_history/fileupload.html
@@ -9,11 +9,16 @@ created_by: {{ item.created_by }}<br>
 item_ark: {{ item.item_ark }}<br>
 {% endfor %}
 {% if messages %}
-<ul class = "messages">
     {% for message in messages %}
-    <li{% if message.tags %} class = "{{ message.tags }}"{% endif %}>{{ message }}</li>
+    <div class="container-fluid p-0">
+      <div class="alert {{ message.tags }} alert-dismissible" role="alert" >
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="True">&times;</span>
+        </button>
+        {{ message }}
+      </div>
+    </div>
     {% endfor %}
-</ul>
 {% endif %}
 <br>
 <form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="skip_upload(this);">

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -2,6 +2,8 @@ from django.shortcuts import render
 from .forms import FileUploadForm, ProjectsForm
 from .models import ProjectItems
 from django.core.management import call_command
+from django.contrib import messages
+from django.core.management.base import CommandError
 
 
 def projects_new(request):
@@ -15,22 +17,43 @@ def upload_file(request):
 
     if request.method == 'POST':
         form = FileUploadForm(request.POST)
-        # Commented-out code in case we want to really upload files after all.
-        # Print statements go to django logs, for QAD dev
-        # form = FileUploadForm(request.POST, request.FILES)
-        # selected_file = request.FILES['selected_file']
-        # print(f'selected_file => {selected_file}')
-        # print(f'Name => {selected_file.name}')
-        # print(f'Size => {selected_file.size}')
-        # print(f'Type => {selected_file.content_type}')
-        # print(f'File Group => {selected_file.name}')
-        # print(request.POST.get('file_group'))
-        file_group = request.POST.get('file_group')
-        item_ark = query_results[0].item_ark
-        file_name = request.POST['file_name']
-        call_command('run_script', file_group=file_group, file_name=file_name,
-                     item_ark=item_ark)
-        # print(file_name)
+        if form.is_valid():
+            # Commented-out code in case we want to really upload files after all.
+            # Print statements go to django logs, for QAD dev
+            # form = FileUploadForm(request.POST, request.FILES)
+            # selected_file = request.FILES['selected_file']
+            # print(f'selected_file => {selected_file}')
+            # print(f'Name => {selected_file.name}')
+            # print(f'Size => {selected_file.size}')
+            # print(f'Type => {selected_file.content_type}')
+            # print(f'File Group => {selected_file.name}')
+            # print(request.POST.get('file_group'))
+            file_group = request.POST.get('file_group')
+            item_ark = query_results[0].item_ark
+            file_name = request.POST['file_name']
+
+            try:
+                call_command('run_script', file_group=file_group, file_name=file_name,
+                             item_ark=item_ark)
+                # print(file_name)
+                messages.success(
+                    request, "The media file was successfully processed")
+
+            # CommandErrors is set in the media processing script
+            except CommandError as e:
+                print(str(e))
+                messages.error(
+                    request, str(e))
+            except ZeroDivisionError as e:
+                messages.error(
+                    request, "Zero division error: " + str(e))
+            except Exception as e:
+                messages.error(
+                    request, "General error: " + str(e))
+
+        else:
+            messages.error(
+                request, "Please check the form fields and resubmit")
     else:
         form = FileUploadForm()
 


### PR DESCRIPTION
Connected to [SYS-805](https://jira.library.ucla.edu/browse/SYS-805)

The Django Messaging Framework was implemented to display status or error messages in the current page being viewed. Status or error messages from the media file processing script display in the same window used by the file upload process (display on the file-picker page).

-----
**Acceptance criteria:**

- [x] The Django Messaging Framework is implemented in the Django application
- [x] Status/error messages are displayed on the current window
- [x] Messages from the media file processing script display in the same window
- [x] Messages persist until dismissed by the user
- [x] Implementation does not conflict with standard Django/python error logging

-----
**Typical Screenshots**

![image](https://user-images.githubusercontent.com/2350153/167733216-1cba045c-4a3f-4ecb-921c-e50061405755.png)

-----
**Changed Files**
```
dlcs_staff_ui/
    settings.py
oral_history/management/commands/
    run_script.py
    scripts/
        process.py
    templates/oral_history/
        base.html
        fileupload.html
    views.py
```