### PR TITLE
SYS-806: Initial Helm chart

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -7,7 +7,7 @@ DJANGO_LOG_LEVEL=INFO
 
 # For database
 DJANGO_DB_USER=oh_owner
-DJANGO_DB_PASS=oh_owner_secret
+DJANGO_DB_PASSWORD=oh_owner_secret
 DJANGO_DB_DSN=db:1521/xepdb1
 
 # For createsuperuser

--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -10,6 +10,9 @@ DJANGO_DB_USER=oh_owner
 DJANGO_DB_PASSWORD=oh_owner_secret
 DJANGO_DB_DSN=db:1521/xepdb1
 
+# Directory containing files "uploaded" by staff
+DJANGO_DLCS_FILE_SOURCE=.
+
 # For createsuperuser
 DJANGO_SUPERUSER_USERNAME=admin
 DJANGO_SUPERUSER_PASSWORD=admin

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ docker-compose exec django bash
 # If using a file, keep it out of the git repo by including "secret" or "password" in the filename.
 DJANGO_DB_DSN=remote_database_domain:1521/remote_oracle_service_name
 DJANGO_DB_USER=remote_username
-DJANGO_DB_PASS=remote_password
+DJANGO_DB_PASSWORD=remote_password
 
 # Inspect the remote database using Django's management command
 # Full schema
@@ -144,7 +144,7 @@ requires a different DSN for database connection (remote user and password are t
 # host.docker.internal is a "magic" docker domain which allows docker to connect to host network resources
 DJANGO_DB_DSN=host.docker.internal:1599/remote_oracle_service_name
 DJANGO_DB_USER=remote_username
-DJANGO_DB_PASS=remote_password
+DJANGO_DB_PASSWORD=remote_password
 ```
 
 ### Application operation

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "0.1"
+description: Chart for new DLCS Staff UI
+name: dlcs-staff-ui
+version: 0.0.1

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "dlcs-staff-ui.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dlcs-staff-ui.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dlcs-staff-ui.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dlcs-staff-ui.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dlcs-staff-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dlcs-staff-ui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dlcs-staff-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dlcs-staff-ui.labels" -}}
+helm.sh/chart: {{ include "dlcs-staff-ui.chart" . }}
+{{ include "dlcs-staff-ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dlcs-staff-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dlcs-staff-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
   DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
   DJANGO_DB_DSN: {{ .Values.django.env.db_dsn }}
   DJANGO_DB_USER: {{ .Values.django.env.db_user }}
+  DJANGO_DLCS_FILE_SOURCE: {{ .Values.django.env.dlcs_file_source }}

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dlcs-staff-ui.fullname" . }}-configmap
+  namespace: dlcs-staff-ui{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "dlcs-staff-ui.labels" . | nindent 4 }}
+data:
+  DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
+  DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
+  DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_DB_DSN: {{ .Values.django.env.db_dsn }}
+  DJANGO_DB_USER: {{ .Values.django.env.db_user }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dlcs-staff-ui.fullname" . }}
+  namespace: dlcs-staff-ui{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "dlcs-staff-ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "dlcs-staff-ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dlcs-staff-ui.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "dlcs-staff-ui.fullname" . }}-configmap
+            - secretRef:
+                name: {{ template "dlcs-staff-ui.fullname" . }}-externalsecret
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /upload_file
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          readinessProbe:
+            httpGet:
+              path: /upload_file
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dlcs-staff-ui.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: dlcs-staff-ui{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "dlcs-staff-ui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . | quote }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+     {{- end }}
+{{- end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dlcs-staff-ui.fullname" . }}
+  namespace: dlcs-staff-ui{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "dlcs-staff-ui.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.django.env.target_port | default "8000" }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dlcs-staff-ui.selectorLabels" . | nindent 4 }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,71 @@
+# Default values for dlcs-staff-ui.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/dlcs-staff-ui
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts: []
+    #  - localhost
+    #  - 127.0.0.1
+    #  - [::1]
+    db_dsn: ""
+    db_user: ""
+    # Include if externalSecrets enabled: "false"
+    #db_password: ""
+    target_port: ""
+
+  externalSecrets:
+    enabled: "false"
+    backend: "systemManager"
+    env: {}
+    # Include below if enabled: "true"
+    #  db_password: ""
+    #  django_secret_key: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -41,6 +41,7 @@ django:
     db_user: ""
     # Include if externalSecrets enabled: "false"
     #db_password: ""
+    dlcs_file_source: ""
     target_port: ""
 
   externalSecrets:

--- a/dlcs_staff_ui/settings.py
+++ b/dlcs_staff_ui/settings.py
@@ -80,7 +80,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.oracle',
         'NAME': os.getenv('DJANGO_DB_DSN'),
         'USER': os.getenv('DJANGO_DB_USER'),
-        'PASSWORD': os.getenv('DJANGO_DB_PASS'),
+        'PASSWORD': os.getenv('DJANGO_DB_PASSWORD'),
         'HOST': '',
         'PORT': '',
     }

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # Tried script from https://github.com/vishnubob/wait-for-it
 # but it's not reliable for Oracle; listener may be up but db not ready.
 # Logs will show error until database is ready, which is OK.
-until python -c "import os ; import cx_Oracle ; conn = cx_Oracle.connect(os.environ.get('DJANGO_DB_USER'), os.environ.get('DJANGO_DB_PASS'), os.environ.get('DJANGO_DB_DSN'))" ; do
+until python -c "import os ; import cx_Oracle ; conn = cx_Oracle.connect(os.environ.get('DJANGO_DB_USER'), os.environ.get('DJANGO_DB_PASSWORD'), os.environ.get('DJANGO_DB_DSN'))" ; do
   echo "Database connection not ready - waiting"
   sleep 10
 done


### PR DESCRIPTION
This PR adds the initial version of the Helm chart for this application.  It was cloned and modified from the LBS Helm chart.  This one is simpler - fewer environment variables, anyhow.
Other than the chart itself:
* Changes `DJANGO_DB_PASS` env var to `DJANGO_DB_PASSWORD` for clarity and consistency with other apps
* Add `DJANGO_DLCS_FILE_SOURCE` env var, intended to indicate where processing script should find "uploaded" files
