### PR TITLE
SYS-808 - Get target directory for derivative

### DIFF
--- a/oral_history/admin.py
+++ b/oral_history/admin.py
@@ -1,15 +1,17 @@
 from django.contrib import admin
 from .models import ContentFiles, FileGroups, Projects, ProjectItems
 
+
 @admin.register(ContentFiles)
 class ContentFilesAdmin(admin.ModelAdmin):
-    list_display = ('fileid_pk', 'file_groupid_fk', 'divid_fk', 'mime_type', 'file_sequence', 'file_size', 
+    list_display = ('fileid_pk', 'file_groupid_fk', 'divid_fk', 'mime_type', 'file_sequence', 'file_size',
                     'create_date', 'file_location', 'location_type', 'file_use', 'file_name', 'content_type')
 
 
 @admin.register(FileGroups)
 class ProjectGroupsAdmin(admin.ModelAdmin):
-    list_display = ('file_groupid_pk', 'projectid_fk', 'file_group_title', 'description')
+    list_display = ('file_groupid_pk', 'projectid_fk',
+                    'file_group_title', 'description')
 
 
 @admin.register(Projects)
@@ -23,3 +25,7 @@ class ProjectItemsAdmin(admin.ModelAdmin):
                     'item_sequence', 'old_divid', 'old_parent_divid', 'node_title', 'statusid_fk', 'created_by', 'modified_by', 'approved_by')
     search_fields = ('created_by', 'modified_by')
 
+
+@admin.register(Projects)
+class ProjectsAdmin(admin.ModelAdmin):
+    list_display = ('projectid_pk', 'project_title', 'image_masters_dir')

--- a/oral_history/admin.py
+++ b/oral_history/admin.py
@@ -24,8 +24,3 @@ class ProjectItemsAdmin(admin.ModelAdmin):
     list_display = ('divid_pk', 'objectid_fk', 'create_date', 'last_edit_date', 'projectid_fk', 'item_ark', 'sent_to_dpr_flag', 'parent_divid',
                     'item_sequence', 'old_divid', 'old_parent_divid', 'node_title', 'statusid_fk', 'created_by', 'modified_by', 'approved_by')
     search_fields = ('created_by', 'modified_by')
-
-
-@admin.register(Projects)
-class ProjectsAdmin(admin.ModelAdmin):
-    list_display = ('projectid_pk', 'project_title', 'image_masters_dir')

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -8,8 +8,7 @@ logger = logging.getLogger(__name__)
 def calculate_destination_dir(mime_type, item_ark):
     # https://jira.library.ucla.edu/browse/SYS-808
     # Based on MIME type and project, the destination dir will differ
-    # TODO:
-    # Need to use ark to go to DB, get project ID, then get directory
+    # The ark is used to go to DB, get project ID, then get directory
     # based on the mimetype
     try:
         if mime_type in ['image/tif', 'image/tiff']:
@@ -22,13 +21,15 @@ def calculate_destination_dir(mime_type, item_ark):
             submasters_dir_to_find = 'text_submasters_dir'
 
         pfk_value = ProjectItems.objects.filter(
-            item_ark=item_ark).values('projectid_fk')[0]['projectid_fk']
-        submasters_dir = Projects.objects.filter(
-            projectid_pk=pfk_value).values(submasters_dir_to_find)[0][submasters_dir_to_find]
+            item_ark=item_ark).first().projectid_fk_id
+        submasters_dir = getattr(Projects.objects.get(
+            pk=pfk_value), submasters_dir_to_find)
 
-        # temporary for verification
-        print("\nsubmaster dir for " + mime_type +
-              ": " + str(submasters_dir) + "\n")
+        submaster_dir = str(submasters_dir)
+        logger.info(f'{submaster_dir = }')
+
+        submaster_mime = mime_type
+        logger.info(f'{submaster_mime = }')
 
         return submasters_dir
     except Exception as ex:

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from .forms import FileUploadForm, ProjectsForm
-from .models import ProjectItems
+from .models import Projects, ProjectItems
 from django.core.management import call_command
 from django.contrib import messages
 from django.core.management.base import CommandError
@@ -27,6 +27,8 @@ def upload_file(request):
                              item_ark=item_ark)
                 messages.success(
                     request, "The media file was successfully processed")
+                messages.success(request, pfk_value)
+                messages.success(request, path_dir)
 
             # Errors from process_file, called above
             # TODO: Are there more specific errors to be caught?

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from .forms import FileUploadForm, ProjectsForm
-from .models import Projects, ProjectItems
+from .models import ProjectItems
 from django.core.management import call_command
 from django.contrib import messages
 from django.core.management.base import CommandError
@@ -27,8 +27,6 @@ def upload_file(request):
                              item_ark=item_ark)
                 messages.success(
                     request, "The media file was successfully processed")
-                messages.success(request, pfk_value)
-                messages.success(request, path_dir)
 
             # Errors from process_file, called above
             # TODO: Are there more specific errors to be caught?


### PR DESCRIPTION
Connected to [SYS-808](https://jira.library.ucla.edu/browse/SYS-808)

NOTE: admin.py is unchanged. It is included because spacing was automatically changed by VSCode.

After a file is processed, the submitted file is copied to a destination location (the masters directory), and the derivative file (submaster) is copied to a different location. Create a function that, when supplied with mime_type and item_ark, returns the location for the derivative.

These destination locations are located in the PROJECTS table.

-----
**Acceptance criteria:**

- [x] Get data to construct derivative target from database

-----
**Typical Screenshots**

![image](https://user-images.githubusercontent.com/2350153/168959729-fb0240e0-be3f-4fbc-9a74-7c38419bb63d.png)

-----
**Changed Files**
```
oral_history/
    admin.py
    management/
        commands/
            process_file.py
```
