### PR TITLE
SYS-846: Get upload form's file groups list from database

### DIFF
--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -1,21 +1,8 @@
 import os
 from django import forms
-from .models import Projects
+from .models import Projects, FileGroups
 
-FILE_GROUPS = [
-    ('PDF', 'UCLA Center for Oral History Research Interview Collection PDF'),
-    ('Text Transcript', 'Oral History Text - Transcript'),
-    ('Text Index', 'Oral History Text - Index'),
-    ('MasterImage1', 'Oral History Image - Master Image'),
-    ('Text Introduction', 'Oral History Text - Introduction'),
-    ('Text Biography', 'Oral History Text - Biography'),
-    ('Text Interview History', 'Oral History Text - Interview History'),
-    ('Text Appendix', ' Oral History Text - Appendix'),
-    ('PDF Appendix to Interview', ' Appendix to Interview PDF'),
-    ('PDF Résumé', ' Narrator’s Résumé PDF'),
-    ('PDF Legal Agreement', 'PDF Legal Agreement')
-]
-GROUP_DEFAULT = 'PDF'
+FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.all()]
 DLCS_FILE_SOURCE = os.getenv('DJANGO_DLCS_FILE_SOURCE')
 
 class ProjectsForm(forms.ModelForm):
@@ -27,8 +14,7 @@ class ProjectsForm(forms.ModelForm):
 
 class FileUploadForm(forms.Form):
     file_group = forms.ChoiceField(
-        choices=FILE_GROUPS, initial=GROUP_DEFAULT, required=False,)
-    # path set in settings.py
+        choices=FILE_GROUPS, required=True,)
     file_name = forms.FilePathField(
         path=DLCS_FILE_SOURCE, recursive=True, allow_files=True, allow_folders=False,
         )

--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -2,8 +2,9 @@ import os
 from django import forms
 from .models import Projects, FileGroups
 
-FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.all()]
 DLCS_FILE_SOURCE = os.getenv('DJANGO_DLCS_FILE_SOURCE')
+# Get list of tuples of file groups, using primary key as form value
+FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.all()]
 
 class ProjectsForm(forms.ModelForm):
 


### PR DESCRIPTION
This PR replaces the hard-coded `FILE_GROUPS` with a list from the database.  This allows the upload form's `select` list to use primary keys for each file group, which is needed for subsequent updates.  Example from the generated HTML:
```
<option value="317">Oral History Text - Transcript</option>
```

At present, all `FileGroups` objects are listed.  If some are unused, they will be deleted from the database(s) later, and this list will automatically reflect changes to that data.

I also removed the `GROUP_DEFAULT` value, and made the `file_group` form value required.  If the form should have an initial value other than the first value in the list, or other ordering of the list is required, we can make those changes later.

Finally, removed obsolete comment about `settings.py` in the form declaration.
