### PR TITLE
SYS-846: Get FILE_GROUPS data from database

### DIFF
--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -17,7 +17,8 @@ done
 
 if [ "$DJANGO_RUN_ENV" = "dev" ]; then
   # Make sure database migrations are up to date
-  python ./manage.py migrate
+  # --skip-checks allows migrations with an empty db when code refers to models.
+  python ./manage.py migrate --skip-checks
 
   # Create default superuser for dev environment, using django env vars.
   # Logs will show error if this exists, which is OK.

--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -1,22 +1,10 @@
 import os
 from django import forms
-from .models import Projects
+from .models import Projects, FileGroups
 
-FILE_GROUPS = [
-    ('PDF', 'UCLA Center for Oral History Research Interview Collection PDF'),
-    ('Text Transcript', 'Oral History Text - Transcript'),
-    ('Text Index', 'Oral History Text - Index'),
-    ('MasterImage1', 'Oral History Image - Master Image'),
-    ('Text Introduction', 'Oral History Text - Introduction'),
-    ('Text Biography', 'Oral History Text - Biography'),
-    ('Text Interview History', 'Oral History Text - Interview History'),
-    ('Text Appendix', ' Oral History Text - Appendix'),
-    ('PDF Appendix to Interview', ' Appendix to Interview PDF'),
-    ('PDF Résumé', ' Narrator’s Résumé PDF'),
-    ('PDF Legal Agreement', 'PDF Legal Agreement')
-]
-GROUP_DEFAULT = 'PDF'
 DLCS_FILE_SOURCE = os.getenv('DJANGO_DLCS_FILE_SOURCE')
+# Get list of tuples of file groups, using primary key as form value
+FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.all()]
 
 class ProjectsForm(forms.ModelForm):
 
@@ -27,8 +15,7 @@ class ProjectsForm(forms.ModelForm):
 
 class FileUploadForm(forms.Form):
     file_group = forms.ChoiceField(
-        choices=FILE_GROUPS, initial=GROUP_DEFAULT, required=False,)
-    # path set in settings.py
+        choices=FILE_GROUPS, required=True,)
     file_name = forms.FilePathField(
         path=DLCS_FILE_SOURCE, recursive=True, allow_files=True, allow_folders=False,
         )


### PR DESCRIPTION
This PR redoes the work from #32 , which had to be temporarily removed due to a problem found when testing #33 .

The changes to `forms.py` are the same as before.  The fix is via `entrypoint.sh`: adding a flag to `migrate` which tells that to skip system checks when it runs.  Otherwise, Django does a check, sees that a model (`FileGroups`) is being referenced in `forms.py`... but that model does not yet exist when migrations are run against an empty database, so the migrations immediately fail.

This is a somewhat niche case, but does come up during local development when a local db refresh is needed / wanted.
