### PR TITLE
SYS-854: Add environment variables for media directories

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -16,6 +16,19 @@ DJANGO_DLCS_FILE_SOURCE=samples
 # Or absolute path, if preferred
 #DJANGO_DLCS_FILE_SOURCE=/home/django/dlcs-staff-ui/samples
 
+# Various media directories for processed files
+# Relative paths for development, absolute for real mounts
+# Oral History source files
+DJANGO_OH_LIBPARTNERS=media_dev/oh_source
+#DJANGO_OH_LIBPARTNERS=/media/oh_source
+# Masters "shadow landing zone"
+DJANGO_OH_MASTERSLZ=media_dev/oh_lz
+#DJANGO_OH_MASTERSLZ=/media/oh_lz
+# Wowza
+DJANGO_OH_WOWZA=media_dev/oh_wowza
+#DJANGO_OH_WOWZA=/media/oh_wowza
+
+
 # For createsuperuser
 DJANGO_SUPERUSER_USERNAME=admin
 DJANGO_SUPERUSER_PASSWORD=admin

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -12,3 +12,6 @@ data:
   DJANGO_DB_DSN: {{ .Values.django.env.db_dsn }}
   DJANGO_DB_USER: {{ .Values.django.env.db_user }}
   DJANGO_DLCS_FILE_SOURCE: {{ .Values.django.env.dlcs_file_source }}
+  DJANGO_OH_LIBPARTNERS: {{ .Values.django.env.oh_libpartners }}
+  DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
+  DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -43,6 +43,9 @@ django:
     #db_password: ""
     dlcs_file_source: ""
     target_port: ""
+    oh_libpartners: ""
+    oh_masterslz: ""
+    oh_wowza: ""
 
   externalSecrets:
     enabled: "false"

--- a/media_dev/.gitignore
+++ b/media_dev/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+# And these subdirectories
+!oh_lz
+!oh_source
+!oh_wowza

--- a/media_dev/oh_lz/.gitignore
+++ b/media_dev/oh_lz/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/media_dev/oh_source/.gitignore
+++ b/media_dev/oh_source/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/media_dev/oh_wowza/.gitignore
+++ b/media_dev/oh_wowza/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This PR adds 3 environment variables, which should be used by file-processing scripts:
* `DJANGO_OH_LIBPARTNERS` # Oral History source files
* `DJANGO_OH_MASTERSLZ` # Masters "shadow landing zone"
* `DJANGO_OH_WOWZA` # Wowza

It also creates "mock" directories within the Django file system, anchored at `media_dev/`, for scripts to use in development.  Files added to these directories will not be added to the repository, and will need to be deleted manually during development.  If extra directories are needed (say for organizing masters) they can be added to the relevant `.gitignore` exclusions as they're identified.

`DJANGO_OH_LIBPARTNERS` probably could replace `DJANGO_DLCS_FILE_SOURCE`, but I've kept them separate for now.

This also adds these 3 environment variables to the embedded Helm chart `configmap.yaml`.
See also https://github.com/UCLALibrary/charts_values/pull/47 for chart values related to this.
