### PR TITLE
SYS-853: Update modules/settings/environment for deployment

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -1,7 +1,19 @@
 # Arbitrary values used during development, not real, OK for github
 
+# Can be 'dev' or 'test' or prod' (this application defaults to 'dev' if this value not set)
 DJANGO_RUN_ENV=dev
 
+# 'Secret' key for dev only
+DJANGO_SECRET_KEY='django-insecure--g3--6#6p%adl64&qdc$1_stwuk&hn50%gomt9@hnvx#(6ehm*'
+
+# For dev only
+DJANGO_DEBUG=True
+
+# Comma separated list of allowed hosts
+# https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
+
+# Logging
 # DEBUG, INFO, WARNING, ERROR, CRITICAL
 DJANGO_LOG_LEVEL=INFO
 

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 # Data dumps
 models_dump.py
 
+# Local static files collected when testing gunicorn and whitenoise
+staticfiles/

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -29,7 +29,16 @@ fi
 if [ "$DJANGO_RUN_ENV" = "dev" ]; then
   # Experiment with unbuffered output
   PYTHONUNBUFFERED=1 python ./manage.py runserver 0.0.0.0:8000
-#else
-  # Start the production app server
-  #gunicorn proj.wsgi:application (or whatever)
+else
+  # Build static files directory, starting fresh each time - do we really need this?
+  python manage.py collectstatic --no-input
+
+  # Start the Gunicorn web server
+  # Gunicorn cmd line flags:
+  # -w number of gunicorn worker processes
+  # -b IPADDR:PORT binding
+  # -t timeout in seconds.  This may need to be large for long-running file conversions, until async is added.
+  # --access-logfile where to send HTTP access logs (- is stdout)
+  export GUNICORN_CMD_ARGS="-w 3 -b 0.0.0.0:8000 -t 600 --access-logfile -"
+  gunicorn dlcs_staff_ui.wsgi:application
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ cx_Oracle == 8.3.0
 ffmpeg-python == 0.2.0
 # Wrapper for imagemagick
 wand == 0.6.7
+gunicorn==20.1.0
+whitenoise==6.0.0


### PR DESCRIPTION
This PR updates the application to be deployment-ready (I hope...):
* Installs and configures `gunicorn` for application server
* Installs and configures `whitenoise` for static file handling
* Adds 3 environment variables expected but not configured

Tested locally by setting `DJANGO_RUN_ENV=test`.  The output shows a warning that a `static` directory is expected in configuration but not present, which is OK for now.