### PR TITLE
Refactor of destination directory using new env variables

### DIFF
--- a/oral_history/scripts/audio_processor.py
+++ b/oral_history/scripts/audio_processor.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 from django.core.management.base import CommandError
 from oral_history.models import ContentFiles
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -14,21 +15,23 @@ class AudioProcessor():
 
     AUDIO_CONTENT_TYPE = "Audio"
 
-    def __init__(self, src_file_name):
+    def __init__(self, src_file_name, file_sequence):
         self.src_file_name = src_file_name
+        self.file_sequence = file_sequence
+
         logger.info(f'Processing audio: {src_file_name}')
 
-    def populate_content_file_data(self, file_path):
+    def populate_content_file_data(self, file_path, location_type):
         
         mime_type, encoding = mimetypes.guess_type(file_path)
 
         content_metadata = ContentFiles()
         content_metadata.mime_type = mime_type
-        content_metadata.file_sequence = 0
+        content_metadata.file_sequence = self.file_sequence
         content_metadata.file_size = os.path.getsize(file_path)
         content_metadata.create_date = datetime.date.today()
         content_metadata.file_location = file_path
-        content_metadata.location_type = 'Submaster'
+        content_metadata.location_type = location_type
         content_metadata.content_type = self.AUDIO_CONTENT_TYPE
 
         return content_metadata
@@ -38,7 +41,8 @@ class AudioProcessor():
         logger.info(f"Mp3 generation with source and output files: ('{self.src_file_name}', '{dest_file_name} )")
 
         try:
-
+            self.create_dest_dir(dest_file_name)
+            
             # Minimum acceptable parameters for wav conversion
             # acodec : libmp3lame - Standard mp3 encoder selection
             # audio_bitrate : 320k - High(er) constant bitrate chosen over VBR for device compatiblity reasons
@@ -50,11 +54,20 @@ class AudioProcessor():
             stream = ffmpeg.output(stream, dest_file_name, acodec='libmp3lame', audio_bitrate='320k', ar=44100, ac=2)
             ffmpeg.run(stream)
 
-            audio_metadata = self.populate_content_file_data(dest_file_name)
+            audio_metadata = self.populate_content_file_data(dest_file_name, "submaster")
+
+            logger.info(f'Audio processed: {dest_file_name}')
 
             return audio_metadata
 
         except:
             raise CommandError(f'Error processing file')
+    
+    def create_dest_dir(self, dest_file_name):
         
-        logger.info(f'Audio processed: {dest_file_name}')
+        p = Path(dest_file_name)
+        parent_path = p.parent
+        parent_path.mkdir(parents=True, exist_ok=True)
+
+        
+        

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -6,6 +6,7 @@ import mimetypes
 import os
 from django.core.management.base import CommandError
 from oral_history.models import ContentFiles
+from pathlib import Path
 from wand.image import Image
 
 logger = logging.getLogger(__name__)
@@ -19,8 +20,10 @@ class ImageProcessor():
     IMAGE_CONTENT_TYPE = "Image"
 
 
-    def __init__(self, src_file_name):
+    def __init__(self, src_file_name, file_sequence):
         self.src_file_name = src_file_name
+        self.file_sequence = file_sequence
+
         logger.info(f'Processing image: {src_file_name}')
 
     def create_thumbnail(self, dest_file_name, resize_height, resize_width):
@@ -33,7 +36,7 @@ class ImageProcessor():
 
         img_metadata = ContentFiles()
         img_metadata.mime_type = mime_type
-        img_metadata.file_sequence = 0
+        img_metadata.file_sequence = self.file_sequence
         img_metadata.file_size = os.path.getsize(file_path)
         img_metadata.create_date = datetime.date.today()
         img_metadata.file_location = file_path
@@ -57,4 +60,8 @@ class ImageProcessor():
         except:
             raise CommandError(f'Error processing file')
         
-        logger.info(f'Image processed: {dest_file_name}')
+    def create_dest_dir(self, dest_file_name):
+        
+        p = Path(dest_file_name)
+        parent_path = p.parent
+        parent_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR is a refactor of the destination folder based on media type to work with the new environment variables, after this is reviewed and requested changes are made, the pdf/txt file processing PRs will be submitted.

Due to the legacy way files are grouped together, a few decisions were made that may seem odd.

The process of an audio submaster can be tested using the following django management command

`python manage.py process_file -a 21198/zz002dx6v0 -f /home/django/dlcs-staff-ui/samples/example_project/sample.wav -g 315`

This will process the sample.wav file (currently, only as a submaster), and assign file group 315.

The end result will be a file located in:
`dlcs-staff-ui/media_dev/oh_wowza/oralhistory/audio/submasters/21198-zz002dx6v0-1-submaster.mp3`

The clunkiest refactor is currently content files are "grouped" together using the file sequence value. If these are not the same for all related derivatives, one cannot track them, for instance to find the related submaster if you know the master file id. For example, if one submits an audio file, a content file record representing the master and submaster should be created, these must share the same file sequence value, there is no other way to link these together.

Reminder, in current functionality, *only* a submaster is created given the example above. Adding a master will be a future ticket and can be quickly added, as it is the equivalent of copying a file.

