### PR TITLE
SYS-861: Show application log via web

### DIFF
--- a/oral_history/templates/oral_history/logs.html
+++ b/oral_history/templates/oral_history/logs.html
@@ -1,0 +1,8 @@
+{% extends 'oral_history/base.html' %}
+
+{% block content %}
+<h3>Super QAD Log Dumper</h3>
+<pre>
+{{ log_data }}
+</pre>
+{% endblock %}

--- a/oral_history/urls.py
+++ b/oral_history/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('projects/new', views.projects_new, name='projects_new'),
     path('table', views.projects_table, name='projects_table'),
     path('upload_file', views.upload_file, name='upload_file'),
+    path('view_logs', views.view_logs, name='view_logs'),
 ]

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -50,3 +50,14 @@ def upload_file(request):
 def projects_table(request):
     query_results = ProjectItems.objects.all()
     return render(request, 'oral_history/table.html', {'query_results': query_results})
+
+
+def view_logs(request):
+    log_file = 'logs/application.log'
+    try:
+        with open(log_file, 'r') as f:
+            log_data = f.read()
+    except FileNotFoundError as ex:
+        log_data = f'Log file {log_file} not found'
+
+    return render(request, 'oral_history/logs.html', {'log_data': log_data})


### PR DESCRIPTION
This PR adds a __very__ quick & dirty ability to view the current log file `logs/application.log` at `/view_logs`.  This is solely to allow devs to view logs for the deployed application, which they can't do now.

This should be protected by Django login, but I had trouble getting that to work.  Having the log publicly available could be a security risk, mitigated by us not logging any secrets or sensitive information.

Testing:
* Confirm `logs/application.log` exists - restarting the Django container will do that, if needed.
* Visit http://127.0.0.1:8000/view_logs
