### PR TITLE
SYS-872: Limit form and view to project 80, Oral History

### DIFF
--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -1,10 +1,11 @@
 import os
 from django import forms
 from .models import Projects, FileGroups
+from .settings import PROJECT_ID
 
 DLCS_FILE_SOURCE = os.getenv('DJANGO_DLCS_FILE_SOURCE')
 # Get list of tuples of Oral History Project file groups, using primary key as form value
-FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.filter(projectid_fk_id__exact=80)]
+FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.filter(projectid_fk_id__exact=PROJECT_ID)]
 
 class ProjectsForm(forms.ModelForm):
 

--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -3,8 +3,8 @@ from django import forms
 from .models import Projects, FileGroups
 
 DLCS_FILE_SOURCE = os.getenv('DJANGO_DLCS_FILE_SOURCE')
-# Get list of tuples of file groups, using primary key as form value
-FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.all()]
+# Get list of tuples of Oral History Project file groups, using primary key as form value
+FILE_GROUPS = [(f.pk, f.description) for f in FileGroups.objects.filter(projectid_fk_id__exact=80)]
 
 class ProjectsForm(forms.ModelForm):
 

--- a/oral_history/settings.py
+++ b/oral_history/settings.py
@@ -1,0 +1,4 @@
+# This contains settings specific to the Oral History application.
+# If other DLCS applications are eventually added to this Django project,
+# corresponding settings will go in their specific application settings files.
+PROJECT_ID = 80

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -47,8 +47,10 @@ def upload_file(request):
     return render(request, 'oral_history/fileupload.html', {'form': form, 'query_results': query_results})
 
 
+# Temporary "test harness" view, providing a local interface to the fileupload form
 def projects_table(request):
-    query_results = ProjectItems.objects.all()
+    # Retrieve up to 10 of the "first" project items
+    query_results = ProjectItems.objects.filter(projectid_fk_id__exact=80)[:10]
     return render(request, 'oral_history/table.html', {'query_results': query_results})
 
 

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from .forms import FileUploadForm, ProjectsForm
 from .models import ProjectItems
+from .settings import PROJECT_ID
 from django.core.management import call_command
 from django.contrib import messages
 from django.core.management.base import CommandError
@@ -50,7 +51,7 @@ def upload_file(request):
 # Temporary "test harness" view, providing a local interface to the fileupload form
 def projects_table(request):
     # Retrieve up to 10 of the "first" project items
-    query_results = ProjectItems.objects.filter(projectid_fk_id__exact=80)[:10]
+    query_results = ProjectItems.objects.filter(projectid_fk_id__exact=PROJECT_ID)[:10]
     return render(request, 'oral_history/table.html', {'query_results': query_results})
 
 


### PR DESCRIPTION
This PR 
* Limits the file group list on `uploadfile` form to just the values for the Oral History project
* Limits the project items on `table` test harness view to the "first" 10 values for Oral History
* Replaces hard-coded OH project_id with value from OH application-specific settings file

Tested with both local database (no changes since sample data is already limited) and when connected to the DLCS QA database, both via `manage.py shell` (easy) and the UI itself (harder, not recommended...).
