### PR TITLE
SYS-879: Fix bug with None in get_local_root_dir()

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -39,6 +39,9 @@ DJANGO_OH_MASTERSLZ=media_dev/oh_lz
 # Wowza
 DJANGO_OH_WOWZA=media_dev/oh_wowza
 #DJANGO_OH_WOWZA=/media/oh_wowza
+# Static files
+DJANGO_OH_STATIC=media_dev/oh_static
+#DJANGO_OH_STATIC=/media/oh_static
 
 
 # For createsuperuser

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -14,4 +14,6 @@ data:
   DJANGO_DLCS_FILE_SOURCE: {{ .Values.django.env.dlcs_file_source }}
   DJANGO_OH_LIBPARTNERS: {{ .Values.django.env.oh_libpartners }}
   DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
+  # oh_static is not yet mounted: https://jira.library.ucla.edu/browse/SYS-862
+  #DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
   DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}

--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -45,6 +45,8 @@ django:
     dlcs_file_source: "samples"
     oh_libpartners: "/media/oh_source"
     oh_masterslz: "/media/oh_lz"
+    # oh_static is not yet mounted: https://jira.library.ucla.edu/browse/SYS-862
+    #oh_static: "/media/oh_static"
     oh_wowza: "/media/oh_wowza"
 
   externalSecrets:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -45,6 +45,8 @@ django:
     target_port: ""
     oh_libpartners: ""
     oh_masterslz: ""
+    # oh_static is not yet mounted: https://jira.library.ucla.edu/browse/SYS-862
+    #oh_static: ""
     oh_wowza: ""
 
   externalSecrets:

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -58,10 +58,13 @@ def get_local_root_dir(media_type, file_use):
             local_root = os.getenv('DJANGO_OH_WOWZA')
         
         else:
-            local_root = os.getenv('DJANGO_OH_SUBMASTERSLZ')
+            local_root = os.getenv('DJANGO_OH_STATIC')
     
     elif file_use == "thumbnail":
-        local_root = os.getenv('DJANGO_OH_THUMBNAILSLZ')
+        local_root = os.getenv('DJANGO_OH_STATIC')
+
+    if local_root is None:
+        raise ValueError(f'local_root is not set: {media_type = }, {file_use = }')
     
     return local_root
     


### PR DESCRIPTION
This PR fixes a bug in `get_local_root_dir()`, which could return `None`, leading to problems in the calling `calculate_destination_dir()`: including `None` in a python f-string results in the string `None`, not an exception as expected with regular string concatenation.

Since returning `None` from `get_local_root_dir()` indicates a problem, I changed that routine to throw `ValueError` instead.  The caller catches that and the error passes up to the UI.

The bug occurred in several cases, because two environment variables were not yet defined.  Both of those have been changed to use `DJANGO_OH_STATIC`, which now is defined.  Most of the updates in this PR are for the Helm chart, though only as placeholders for now since the underlying mount has not yet been added.

Testing of the (currently) 12 potential cases, though not all of them may be valid - but that's a separate issue:
```
$ docker-compose exec django python manage.py shell
Python 3.9.10 (main, Jan 18 2022, 21:24:53)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import foo
mt = 'audio', fu = 'master', lr = 'media_dev/oh_lz'
mt = 'audio', fu = 'submaster', lr = 'media_dev/oh_wowza'
mt = 'audio', fu = 'thumbnail', lr = 'media_dev/oh_static'
mt = 'image', fu = 'master', lr = 'media_dev/oh_lz'
mt = 'image', fu = 'submaster', lr = 'media_dev/oh_static'
mt = 'image', fu = 'thumbnail', lr = 'media_dev/oh_static'
mt = 'pdf', fu = 'master', lr = 'media_dev/oh_lz'
mt = 'pdf', fu = 'submaster', lr = 'media_dev/oh_static'
mt = 'pdf', fu = 'thumbnail', lr = 'media_dev/oh_static'
mt = 'text', fu = 'master', lr = 'media_dev/oh_lz'
mt = 'text', fu = 'submaster', lr = 'media_dev/oh_static'
mt = 'text', fu = 'thumbnail', lr = 'media_dev/oh_static'
>>>
now exiting InteractiveConsole...

$ cat foo.py
import oral_history.management.commands.process_file as pf

for mt in ['audio', 'image', 'pdf', 'text']:
  for fu in ['master', 'submaster', 'thumbnail']:
    try:
      lr = pf.get_local_root_dir(mt, fu)
      print(f'{mt = }, {fu = }, {lr = }')
    except Exception as ex:
      print(f'{mt = }, {fu = }, {lr = }, {ex = }')
```
