### PR TITLE
SYS-874: Change dlcs_file_source to specific upload directory

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -42,7 +42,8 @@ django:
       - dlcs-staff.library.ucla.edu
     db_dsn: "dba-lib-odb-q01.it.ucla.edu:1521/DLCS"
     db_user: "dlcs"
-    dlcs_file_source: "samples"
+    # Specific directory used for source files
+    dlcs_file_source: "/media/oh_source/upload"
     oh_libpartners: "/media/oh_source"
     oh_masterslz: "/media/oh_lz"
     # oh_static is not yet mounted: https://jira.library.ucla.edu/browse/SYS-862


### PR DESCRIPTION
This PR changes `dlcs_file_source` to point to a specific upload directory in the deployed container.  This should avoid the problem caused by too many files in the main directory.
