### PR TITLE
Sys 877/image submaster add

### DIFF
--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -103,7 +103,7 @@ def get_media_folder_by_mime_type(media_type, file_use):
     file_use_folder = get_folder_by_use(file_use)
         
     if media_type == "image":
-        folder_name = "/"
+        folder_name = ""
     
     elif media_type == "audio":
         folder_name = "/audio"
@@ -177,7 +177,7 @@ def process_media_file(file_name, item_ark, file_group):
         media_type = calculate_media_type(file_name)
         
         if media_type == "image":
-            content_file_data = process_tiff(file_name, item_ark, file_group)
+            content_file_data = process_tiff(file_name, item_ark)
         
         elif media_type == "audio":
             content_file_data = process_wav(file_name, item_ark, file_group)
@@ -221,20 +221,21 @@ def process_tiff(file_name, item_ark):
         
         # Thumbnail related operations
         dest_dir = calculate_destination_dir("image", item_ark, "thumbnail")
-        cf_name, file_sequence = get_new_content_file_name(item_ark, "thumbnail", "jpg")
+        cf_name, file_sequence = get_new_content_file_name(item_ark, "thumbnail", ".jpg")
         dest_file_name = f"{dest_dir}{cf_name}"
         logger.info(f'{dest_file_name = }')
 
+        file_group = get_related_file_group("image", "Thumbnail")
         image_processor = ImageProcessor(file_name, file_sequence, file_group)
         img_metadata.append(image_processor.create_thumbnail(dest_file_name, resize_height, resize_width))
 
         # Submaster image related operations
         dest_dir = calculate_destination_dir("image", item_ark, "submaster")
-        cf_name, file_sequence = get_new_content_file_name(item_ark, "submaster", "jpg", file_sequence)
+        cf_name, file_sequence = get_new_content_file_name(item_ark, "submaster", ".jpg", file_sequence)
         dest_file_name = f"{dest_dir}{cf_name}"
         file_group = get_related_file_group("image", "Submaster")
         image_processor.file_group = file_group
-        img_metadata.append(image_processor.create_submaster_img(dest_file_name, resize_height, resize_width))
+        img_metadata.append(image_processor.create_submaster_img(dest_file_name, submaster_img_resize_height, submaster_img_resize_width))
         
         # Master image related operations
         file_ext = Path(file_name).suffix
@@ -245,8 +246,8 @@ def process_tiff(file_name, item_ark):
         
 
         file_group = get_related_file_group("image", "Master")
-        file_processor = FileProcessor(file_name, file_sequence, "master", file_group, "image")
-        img_metadata.append(file_processor.copy_file(dest_file_name, "master"))
+        file_processor = FileProcessor(file_name, file_sequence, file_group, "master", "image")
+        img_metadata.append(file_processor.copy_file(dest_file_name))
 
         return img_metadata
 

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -212,9 +212,14 @@ def process_tiff(file_name, item_ark):
     # but for now just grab side size in 'Image Pixels Long Dimension'
     resize_height = resize_width = thumbnail_settings['Image Pixels Long Dimension']
 
+    # Get submaster image related settings
+    submaster_img_settings = get_submaster_image_settings()
+    submaster_img_resize_height = submaster_img_resize_width = submaster_img_settings['Image Pixels Long Dimension']
+
     try:
         img_metadata = []
         
+        # Thumbnail related operations
         dest_dir = calculate_destination_dir("image", item_ark, "thumbnail")
         cf_name, file_sequence = get_new_content_file_name(item_ark, "thumbnail", "jpg")
         dest_file_name = f"{dest_dir}{cf_name}"
@@ -223,11 +228,21 @@ def process_tiff(file_name, item_ark):
         image_processor = ImageProcessor(file_name, file_sequence, file_group)
         img_metadata.append(image_processor.create_thumbnail(dest_file_name, resize_height, resize_width))
 
+        # Submaster image related operations
+        dest_dir = calculate_destination_dir("image", item_ark, "submaster")
+        cf_name, file_sequence = get_new_content_file_name(item_ark, "submaster", "jpg", file_sequence)
+        dest_file_name = f"{dest_dir}{cf_name}"
+        file_group = get_related_file_group("image", "Submaster")
+        image_processor.file_group = file_group
+        img_metadata.append(image_processor.create_submaster_img(dest_file_name, resize_height, resize_width))
+        
+        # Master image related operations
         file_ext = Path(file_name).suffix
 
         dest_dir = calculate_destination_dir("image", item_ark, "master")
         cf_name, file_sequence = get_new_content_file_name(item_ark, "master", file_ext, file_sequence)
         dest_file_name = f"{dest_dir}{cf_name}"
+        
 
         file_group = get_related_file_group("image", "Master")
         file_processor = FileProcessor(file_name, file_sequence, "master", file_group, "image")
@@ -344,9 +359,17 @@ def get_new_content_file_name(item_ark, file_use, file_extension, file_seq_overr
 
 
 def get_thumbnail_settings():
-    # Retrieve default thumbnail settings from database.
+    return get_image_settings("Image Thumbnail Technical MD")
+
+
+def get_submaster_image_settings():
+    return get_image_settings("Image Submaster Technical MD")
+
+
+def get_image_settings(admin_group_title):
+    # Retrieve default image settings from database based on image admin group submitted
     query_data = AdminValues.objects.filter(
-        admin_groupid_fk__admin_group_title__exact='Image Thumbnail Technical MD',
+        admin_groupid_fk__admin_group_title__exact=admin_group_title,
         admin_termid_fk__admin_term__in=(
             'Bits Per Sample',
             'Image Pixels Long Dimension',
@@ -357,7 +380,7 @@ def get_thumbnail_settings():
         admin_term=F('admin_termid_fk__admin_term')
         )
     # Convert queryset (list of dictionaries) to single dictionary for easier use.
-    # At present this returns:
+    # At present this returns the following for thumbnails:
     # {
     #     'Image Sampling Frequency': '72',
     #     'Bits Per Sample': '8',
@@ -365,6 +388,7 @@ def get_thumbnail_settings():
     #     'Image Pixels Long Dimension': '200'
     # }
     return {row['admin_term'] : row['admin_value'] for row in query_data}
+
 
 def update_db(content_file_data, item_ark):
     # Adds required foreign keys to ContentFiles object, then saves it.

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -20,9 +20,10 @@ class ImageProcessor():
     IMAGE_CONTENT_TYPE = "Image"
 
 
-    def __init__(self, src_file_name, file_sequence):
+    def __init__(self, src_file_name, file_sequence, file_group):
         self.src_file_name = src_file_name
         self.file_sequence = file_sequence
+        self.file_group = file_group
 
         logger.info(f'Processing image: {src_file_name}')
 
@@ -41,6 +42,7 @@ class ImageProcessor():
         img_metadata = ContentFiles()
         img_metadata.mime_type = mime_type
         img_metadata.file_sequence = self.file_sequence
+        img_metadata.file_groupid_fk_id = self.file_group
         img_metadata.file_size = os.path.getsize(file_path)
         img_metadata.create_date = datetime.date.today()
         img_metadata.file_location = file_path
@@ -53,11 +55,17 @@ class ImageProcessor():
         
         logger.info(f"script('{self.src_file_name}', '{dest_file_name}', '{resize_height}', {resize_width} )")
 
+
         try:
+            self.create_dest_dir(dest_file_name)
+
+            resize_height = int(resize_height)
+            resize_width = int(resize_width)
+            
             with Image(filename=self.src_file_name) as img:
                 img.resize(height=resize_height, width=resize_width)
                 img.save(filename=dest_file_name)
-
+                
                 img_metadata = self.populate_content_file_data(dest_file_name, process_category)
                 return img_metadata
 

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -30,6 +30,10 @@ class ImageProcessor():
         
         return self.resize_image(dest_file_name, resize_height, resize_width, ImageProcessor.THUMBNAIL_CATEGORY)
     
+    def create_submaster_img(self, dest_file_name, resize_height, resize_width):
+
+        return self.resize_image(dest_file_name, resize_height, resize_width, ImageProcessor.SUBMASTER_CATEGORY)
+    
     def populate_content_file_data(self, file_path, image_category):
         
         mime_type, encoding = mimetypes.guess_type(file_path)


### PR DESCRIPTION
Addresses a few issues:
* Adds argument to submit admin group title for similar parameters (submaster and thumbnail use same admin terms)
* Adds submaster generation to `process_tiff()`
* Helper methods in `ImageProcessor()` for thumbnail and submaster options

To test, in django shell run:
`python manage.py process_file -a 21198/zz002dx6v0 -f /home/django/dlcs-staff-ui/samples/example_project/sample.tiff -g 562`

Expected behavior:
3 new files are created, the sequence number may be different but they should all be the same (in case below, 10)
`media_dev/oh_static/oralhistory/nails/21198-zz002dx6v0-10-thumbnail.jpg`
`media_dev/oh_static/oralhistory/submaster/21198-zz002dx6v0-10-submaster.jpg`
`media_dev/oh_lz/oralhistory/masters/21198-zz002dx6v0-10-master.tiff`