### PR TITLE
SYS-881: Work around form caching hiding file system changes

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.6.0
+  tag: v0.7.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -1,5 +1,6 @@
 import os
 from django import forms
+from django.core.cache import cache
 from .models import Projects, FileGroups
 from .settings import PROJECT_ID
 
@@ -17,6 +18,29 @@ class ProjectsForm(forms.ModelForm):
 class FileUploadForm(forms.Form):
     file_group = forms.ChoiceField(
         choices=FILE_GROUPS, required=True,)
-    file_name = forms.FilePathField(
-        path=DLCS_FILE_SOURCE, recursive=True, allow_files=True, allow_folders=False,
-        )
+    # FilePathField (at least) path gets cached automatically by Django at application startup.
+    # There's no direct way to make it see changes to the filesystem.
+    # Workaround from https://stackoverflow.com/questions/30656653/suffering-stale-choices-for-filepathfield
+
+    _file_name_kw = dict(
+        path=DLCS_FILE_SOURCE, 
+        recursive=True, 
+        allow_files=True, 
+        allow_folders=False
+    )
+    file_name = forms.FilePathField(**_file_name_kw)
+
+    # __init__ is called every time the form is needed.
+    # Cache values for 5 seconds (arbitrary); use cache if populated,
+    # otherwise start fresh.
+    def __init__(self, **kwargs):
+        seconds_to_cache = 5
+        key = 'file_name-cache-key'
+        choices = cache.get(key)
+        if not choices:
+            field = forms.FilePathField(**self._file_name_kw)
+            choices = field.choices
+            cache.set(key, choices, seconds_to_cache)
+
+        super().__init__(**kwargs)
+        self.base_fields['file_name'].choices = choices


### PR DESCRIPTION
This PR fixes a ~bug~ unexpected behavior where Django caches form options at startup.  In this case, the `FilePathField` used to select a file for upload does not see changes to the file system, so new / deleted files are not reflected in the `file_name` selector unless Django is restarted.

Manual testing:
```
# Add file
$ ls -al > samples/fake_interviews/foobar1.txt

# Wait 5+ seconds (seems more like 10...)
# Force-refresh the form (browser may cache the form otherwise)
# Observe that the new file is present
# Delete the new file, wait, refresh, observe that it's gone
```
