### PR TITLE
SYS-884: Fix TypeError bug with form's overridden init()

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.7.0
+  tag: v0.7.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/forms.py
+++ b/oral_history/forms.py
@@ -33,7 +33,7 @@ class FileUploadForm(forms.Form):
     # __init__ is called every time the form is needed.
     # Cache values for 5 seconds (arbitrary); use cache if populated,
     # otherwise start fresh.
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         seconds_to_cache = 5
         key = 'file_name-cache-key'
         choices = cache.get(key)
@@ -42,5 +42,5 @@ class FileUploadForm(forms.Form):
             choices = field.choices
             cache.set(key, choices, seconds_to_cache)
 
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
         self.base_fields['file_name'].choices = choices

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -1,3 +1,4 @@
+import logging
 from django.shortcuts import render
 from .forms import FileUploadForm, ProjectsForm
 from .models import ProjectItems
@@ -6,6 +7,7 @@ from django.core.management import call_command
 from django.contrib import messages
 from django.core.management.base import CommandError
 
+logger = logging.getLogger(__name__)
 
 def projects_new(request):
     form = ProjectsForm()


### PR DESCRIPTION
This PR fixes a bug introduced by SYS-881 (#62), which caused a TypeError when the form is submitted:
```
Exception Value: __init__() takes 1 positional argument but 2 were given
File "/home/django/dlcs-staff-ui/oral_history/views.py", line 20, in upload_file
    form = FileUploadForm(request.POST)
```
Either the code I copy/pasted was incomplete, or Django has changed since that was posted.  In our situation at least, the overridden `__init__` methods needed both `*args` and `**kwargs` passed to them, not just `**kwargs` as I did.

Tag bumped to `v0.7.1` for deployment.
