### PR TITLE
SYS-893: Show 'Please Wait' message after submitting file upload form

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.1
+  tag: v0.8.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/templates/oral_history/base.html
+++ b/oral_history/templates/oral_history/base.html
@@ -2,6 +2,9 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <!-- Custom JS -->
+        <script src="{% static 'js/main.js' %}" defer></script>
+
         <!-- Include jquery and bootstrap - use versions compatible with each other -->
         <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>

--- a/oral_history/templates/oral_history/fileupload.html
+++ b/oral_history/templates/oral_history/fileupload.html
@@ -21,9 +21,9 @@ item_ark: {{ item.item_ark }}<br>
     {% endfor %}
 {% endif %}
 <br>
-<form name="upload_file_form" method="POST" enctype="multipart/form-data">
+<form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="disable_upload_button(this);">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Save</button>
+    <button type="submit" id="upload_button">Upload</button>
 </form>
 {% endblock %}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,9 @@
+// Custom javascript for the oral history staff ui
+
+// Disable file upload submit button once clicked.
+// The button is restored to normal once Django completes processing and re-renders the form.
+function disable_upload_button(form) {
+	btn = form.elements.upload_button;
+	btn.textContent = "Please wait...";
+	btn.disabled = true;
+}


### PR DESCRIPTION
This PR adds a simple javascript function.  When the upload form is submitted:
* Change the "Upload" button to say "Please wait..."
* Disable the "Upload" button until the requested processing is done.

Bumps image tag to `v0.8.2` for deployment.

This is awkward to test locally as our sample files are so small there's nothing to wait for.  I tested by inserting `import time; time.sleep(10)` into `process_file` just above the call to `process_media_file`.  See screenshots for sample results:

![upload_please_wait](https://user-images.githubusercontent.com/2213836/176570294-b299b592-0e96-4b49-be0d-654d69399acc.png)

![upload_done](https://user-images.githubusercontent.com/2213836/176570313-48f50e38-c6a7-48d1-a507-f5ea6721d66b.png)


