### PR TITLE
Corrected ContentFiles fields in processor files

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.1
+  tag: v0.8.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -247,7 +247,7 @@ def process_tiff(file_name, item_ark):
         logger.info(f'{dest_file_name = }')
 
         file_group = get_related_file_group("image", "Master")
-        file_processor = FileProcessor(file_name, file_sequence, file_group, "master", "image")
+        file_processor = FileProcessor(file_name, file_sequence, file_group, "Master", "Image")
         img_metadata.append(file_processor.copy_file(dest_file_name))
 
         return img_metadata
@@ -268,7 +268,7 @@ def process_wav(file_name, item_ark, file_group):
         logger.info(f'{dest_file_name = }')
 
         file_group = get_related_file_group("audio", "Submaster")
-        audio_processor = AudioProcessor(file_name, file_sequence, file_group, "submaster")
+        audio_processor = AudioProcessor(file_name, file_sequence, file_group, "Submaster")
         audio_metadata.append(audio_processor.create_audio_mp3(dest_file_name))
 
         file_ext = Path(file_name).suffix
@@ -279,7 +279,7 @@ def process_wav(file_name, item_ark, file_group):
         logger.info(f'{dest_file_name = }')
 
         file_group = get_related_file_group("audio", "Master")
-        file_processor = FileProcessor(file_name, file_sequence, file_group, "master", "audio")
+        file_processor = FileProcessor(file_name, file_sequence, file_group, "Master", "Audio")
         audio_metadata.append(file_processor.copy_file(dest_file_name))
 
         return audio_metadata
@@ -299,14 +299,14 @@ def process_file(file_name, item_ark, media_type, file_group):
     dest_dir = calculate_destination_dir(media_type, item_ark, "submaster")
     cf_name, file_sequence = get_new_content_file_name(item_ark, "submaster", file_ext)
     dest_file_name = f"{dest_dir}{cf_name}"
-    file_processor = FileProcessor(file_name, file_sequence, file_group, "submaster", media_type)
+    file_processor = FileProcessor(file_name, file_sequence, file_group, "Submaster", media_type)
     file_metadata.append(file_processor.copy_file(dest_file_name))
 
 
     dest_dir = calculate_destination_dir(media_type, item_ark, "master")
     cf_name, file_sequence = get_new_content_file_name(item_ark, "master", file_ext, file_sequence)
     dest_file_name = f"{dest_dir}{cf_name}"
-    file_processor.file_use = "master"
+    file_processor.file_use = "Master"
     file_processor.file_sequence = file_sequence
     file_metadata.append(file_processor.copy_file(dest_file_name))
 

--- a/oral_history/scripts/audio_processor.py
+++ b/oral_history/scripts/audio_processor.py
@@ -29,16 +29,16 @@ class AudioProcessor():
 
         content_metadata = ContentFiles()
         
-        content_metadata.file_sequence = self.file_sequence
-        content_metadata.file_groupid_fk_id = self.file_group
-        content_metadata.file_use = self.file_use
         content_metadata.content_type = self.AUDIO_CONTENT_TYPE
-
-        content_metadata.mime_type = mime_type
-        content_metadata.file_size = os.path.getsize(file_path)
         content_metadata.create_date = datetime.date.today()
+        content_metadata.file_groupid_fk_id = self.file_group
         content_metadata.file_location = file_path
-        
+        content_metadata.file_name = os.path.basename(file_path)
+        content_metadata.file_use = self.file_use
+        content_metadata.file_sequence = self.file_sequence
+        content_metadata.file_size = os.path.getsize(file_path)
+        content_metadata.location_type = "URL"
+        content_metadata.mime_type = mime_type
 
         return content_metadata
     
@@ -54,11 +54,11 @@ class AudioProcessor():
             # audio_bitrate : 320k - High(er) constant bitrate chosen over VBR for device compatiblity reasons
             # ar : 44.1kHz - Matches sample rate of our source file, which will always be 16 bit 44.1khz wav for this project
             # ac : 2 channels - Forces to 2 channels in the case there are more or less present. OH source files will always be 2 channels
+            # overwrite_output : True - Overwrite if existing file
 
             stream = ffmpeg.input(self.src_file_name)
-            # TODO: Add -y flag to override existing output files, or handle another way
             stream = ffmpeg.output(stream, dest_file_name, acodec='libmp3lame', audio_bitrate='320k', ar=44100, ac=2)
-            ffmpeg.run(stream)
+            ffmpeg.run(stream, overwrite_output=True)
 
             audio_metadata = self.populate_content_file_data(dest_file_name)
 

--- a/oral_history/scripts/file_processor.py
+++ b/oral_history/scripts/file_processor.py
@@ -27,16 +27,18 @@ class FileProcessor():
         mime_type, encoding = mimetypes.guess_type(file_path)
 
         content_metadata = ContentFiles()
-        content_metadata.file_groupid_fk_id = self.file_group
-        content_metadata.file_use = self.file_use
-        content_metadata.file_sequence = self.file_sequence
+
         content_metadata.content_type = self.content_type
-
-        content_metadata.mime_type = mime_type
-        content_metadata.file_size = os.path.getsize(file_path)
         content_metadata.create_date = datetime.date.today()
+        content_metadata.file_groupid_fk_id = self.file_group
         content_metadata.file_location = file_path
-
+        content_metadata.file_name = os.path.basename(file_path)
+        content_metadata.file_sequence = self.file_sequence
+        content_metadata.file_size = os.path.getsize(file_path)
+        content_metadata.file_use = self.file_use
+        content_metadata.location_type = "URL"
+        content_metadata.mime_type = mime_type
+        
         return content_metadata
 
     

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -40,14 +40,17 @@ class ImageProcessor():
         mime_type, encoding = mimetypes.guess_type(file_path)
 
         img_metadata = ContentFiles()
-        img_metadata.mime_type = mime_type
-        img_metadata.file_sequence = self.file_sequence
-        img_metadata.file_groupid_fk_id = self.file_group
-        img_metadata.file_size = os.path.getsize(file_path)
-        img_metadata.create_date = datetime.date.today()
-        img_metadata.file_location = file_path
-        img_metadata.location_type = image_category
+        
         img_metadata.content_type = self.IMAGE_CONTENT_TYPE
+        img_metadata.create_date = datetime.date.today()
+        img_metadata.file_groupid_fk_id = self.file_group
+        img_metadata.file_name = os.path.basename(file_path)
+        img_metadata.file_sequence = self.file_sequence
+        img_metadata.file_size = os.path.getsize(file_path)
+        img_metadata.file_use = image_category
+        img_metadata.file_location = file_path
+        img_metadata.mime_type = mime_type
+        img_metadata.location_type = "URL"
 
         return img_metadata
     


### PR DESCRIPTION
A few corrections for values set in a ContentFile object

- location_type always set to `URL`, previously the values were either URL or database. Only URL is valid now
- file_use is set to either Master, Submaster or Thumbnail (first letter is capitalized to match legacy data)
- file_name is set to the destination file name, without path
- content_type is set to the media type, with Audio and Image capitalized to match legacy data

Other items of note:
- `overwrite_output=True` added to ffmpeg call to overwrite existing output
- file_sequence bug found when more than 9 files are added, a separate ticket and possible solution added

To verify:
Start bash shell on container and run the following:
`python manage.py process_file -a 21198/zz002dx6v0 -f /home/django/dlcs-staff-ui/samples/example_project/sample.tiff -g 562`
`python manage.py process_file -a 21198/zz002dx6v0 -f /home/django/dlcs-staff-ui/samples/example_project/sample.wav -g 562`

View ContentFile table values at `http://127.0.0.1:8000/admin/oral_history/contentfiles/` and verify the columns are populated as described above. Previously, file_use was missing, file_name and location_type were incorrect.