### PR TITLE
SYS-895: Set file_location correctly for non-masters

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.3
+  tag: v0.8.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/scripts/audio_processor.py
+++ b/oral_history/scripts/audio_processor.py
@@ -32,7 +32,7 @@ class AudioProcessor():
         content_metadata.content_type = self.AUDIO_CONTENT_TYPE
         content_metadata.create_date = datetime.date.today()
         content_metadata.file_groupid_fk_id = self.file_group
-        content_metadata.file_location = file_path
+        content_metadata.file_location = self.get_url(file_path)
         content_metadata.file_name = os.path.basename(file_path)
         content_metadata.file_use = self.file_use
         content_metadata.file_sequence = self.file_sequence
@@ -75,5 +75,21 @@ class AudioProcessor():
         parent_path = p.parent
         parent_path.mkdir(parents=True, exist_ok=True)
 
+
+    def get_url(self, file_path):
+        # May be fragile: assumes file_path starts with two elements we don't want
+        # Example: /media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # becomes oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # TODO: Refactor to make this generic via an included library.
         
-        
+        # Currently supported only for Submaster
+        if self.file_use in ['Submaster']:
+            # Strip off first two elements of / delimited path, join the rest with /
+            url_path = '/'.join(file_path.split('/')[3:])
+            # Audio uses wowza, not static
+            domain = 'https://wowza.library.ucla.edu'
+            path_prefix = 'dlp/definst/mp3:oralhistory'
+            path_suffix = 'playlist.m3u8'
+            return f'{domain}/{path_prefix}/{url_path}/{path_suffix}'
+        else:
+            return file_path

--- a/oral_history/scripts/audio_processor.py
+++ b/oral_history/scripts/audio_processor.py
@@ -78,18 +78,20 @@ class AudioProcessor():
 
     def get_url(self, file_path):
         # May be fragile: assumes file_path starts with two elements we don't want
-        # Example: /media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # Example: media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
         # becomes oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
         # TODO: Refactor to make this generic via an included library.
         
         # Currently supported only for Submaster
         if self.file_use in ['Submaster']:
             # Strip off first two elements of / delimited path, join the rest with /
-            url_path = '/'.join(file_path.split('/')[3:])
+            url_path = '/'.join(file_path.split('/')[2:])
             # Audio uses wowza, not static
             domain = 'https://wowza.library.ucla.edu'
             path_prefix = 'dlp/definst/mp3:oralhistory'
             path_suffix = 'playlist.m3u8'
-            return f'{domain}/{path_prefix}/{url_path}/{path_suffix}'
+            url = f'{domain}/{path_prefix}/{url_path}/{path_suffix}'
+            logger.info(f'{file_path = }, {url = }')
+            return url
         else:
             return file_path

--- a/oral_history/scripts/file_processor.py
+++ b/oral_history/scripts/file_processor.py
@@ -68,15 +68,17 @@ class FileProcessor():
 
     def get_url(self, file_path):
         # May be fragile: assumes file_path starts with two elements we don't want
-        # Example: /media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # Example: media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
         # becomes oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
         # TODO: Refactor to make this generic via an included library.
         
         # Currently supported only for Submaster and Thumbnail
         if self.file_use in ['Submaster', 'Thumbnail']:
             # Strip off first two elements of / delimited path, join the rest with /
-            url_path = '/'.join(file_path.split('/')[3:])
+            url_path = '/'.join(file_path.split('/')[2:])
             domain = 'https://static.library.ucla.edu'
-            return f'{domain}/{url_path}'
+            url = f'{domain}/{url_path}'
+            logger.info(f'{file_path = }, {url = }')
+            return url
         else:
             return file_path

--- a/oral_history/scripts/file_processor.py
+++ b/oral_history/scripts/file_processor.py
@@ -31,7 +31,7 @@ class FileProcessor():
         content_metadata.content_type = self.content_type
         content_metadata.create_date = datetime.date.today()
         content_metadata.file_groupid_fk_id = self.file_group
-        content_metadata.file_location = file_path
+        content_metadata.file_location = self.get_url(file_path)
         content_metadata.file_name = os.path.basename(file_path)
         content_metadata.file_sequence = self.file_sequence
         content_metadata.file_size = os.path.getsize(file_path)
@@ -65,5 +65,18 @@ class FileProcessor():
         parent_path = p.parent
         parent_path.mkdir(parents=True, exist_ok=True)
 
+
+    def get_url(self, file_path):
+        # May be fragile: assumes file_path starts with two elements we don't want
+        # Example: /media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # becomes oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # TODO: Refactor to make this generic via an included library.
         
-        
+        # Currently supported only for Submaster and Thumbnail
+        if self.file_use in ['Submaster', 'Thumbnail']:
+            # Strip off first two elements of / delimited path, join the rest with /
+            url_path = '/'.join(file_path.split('/')[3:])
+            domain = 'https://static.library.ucla.edu'
+            return f'{domain}/{url_path}'
+        else:
+            return file_path

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -83,15 +83,17 @@ class ImageProcessor():
 
     def get_url(self, file_path, image_category):
         # May be fragile: assumes file_path starts with two elements we don't want
-        # Example: /media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # Example: media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
         # becomes oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
         # TODO: Refactor to make this generic via an included library.
 
         # Currently supported only for Submaster and Thumbnail
         if image_category in [ImageProcessor.SUBMASTER_CATEGORY, ImageProcessor.THUMBNAIL_CATEGORY]:
             # Strip off first two elements of / delimited path, join the rest with /
-            url_path = '/'.join(file_path.split('/')[3:])
+            url_path = '/'.join(file_path.split('/')[2:])
             domain = 'https://static.library.ucla.edu'
-            return f'{domain}/{url_path}'
+            url = f'{domain}/{url_path}'
+            logger.info(f'{file_path = }, {url = }')
+            return url
         else:
             return file_path

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -48,7 +48,7 @@ class ImageProcessor():
         img_metadata.file_sequence = self.file_sequence
         img_metadata.file_size = os.path.getsize(file_path)
         img_metadata.file_use = image_category
-        img_metadata.file_location = file_path
+        img_metadata.file_location = self.get_url(file_path, image_category)
         img_metadata.mime_type = mime_type
         img_metadata.location_type = "URL"
 
@@ -79,3 +79,19 @@ class ImageProcessor():
         p = Path(dest_file_name)
         parent_path = p.parent
         parent_path.mkdir(parents=True, exist_ok=True)
+
+
+    def get_url(self, file_path, image_category):
+        # May be fragile: assumes file_path starts with two elements we don't want
+        # Example: /media/oh_lz/oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # becomes oralhistory-test/masters/21198-zz002kp5wz-1-master.tif
+        # TODO: Refactor to make this generic via an included library.
+
+        # Currently supported only for Submaster and Thumbnail
+        if image_category in [ImageProcessor.SUBMASTER_CATEGORY, ImageProcessor.THUMBNAIL_CATEGORY]:
+            # Strip off first two elements of / delimited path, join the rest with /
+            url_path = '/'.join(file_path.split('/')[3:])
+            domain = 'https://static.library.ucla.edu'
+            return f'{domain}/{url_path}'
+        else:
+            return file_path


### PR DESCRIPTION
This PR adds a `get_url()` function which returns the URL needed for `file_path`, for non-masters only.
The function currently is in all 3 Processor scripts, with minor differences which should be reconciled later with refactoring of the Processor scripts; marked with `TODO` for the future.

Bumps image tag version to `v0.8.4`

**Updated data from local testing**

```
file_path = 'media_dev/oh_static/oralhistory/text/submasters/21198-zz002dx6rf-10-submaster.txt', url = 'https://static.library.ucla.edu/oralhistory/text/submasters/21198-zz002dx6rf-10-submaster.txt'
file_path = 'media_dev/oh_static/oralhistory/pdf/submasters/21198-zz002dx6rf-10-submaster.pdf', url = 'https://static.library.ucla.edu/oralhistory/pdf/submasters/21198-zz002dx6rf-10-submaster.pdf'
file_path = 'media_dev/oh_static/oralhistory/nails/21198-zz002dx6rf-10-thumbnail.jpg', url = 'https://static.library.ucla.edu/oralhistory/nails/21198-zz002dx6rf-10-thumbnail.jpg'
file_path = 'media_dev/oh_static/oralhistory/submasters/21198-zz002dx6rf-10-submaster.jpg', url = 'https://static.library.ucla.edu/oralhistory/submasters/21198-zz002dx6rf-10-submaster.jpg'
file_path = 'media_dev/oh_static/oralhistory/nails/21198-zz002dx6rf-10-thumbnail.jpg', url = 'https://static.library.ucla.edu/oralhistory/nails/21198-zz002dx6rf-10-thumbnail.jpg'
file_path = 'media_dev/oh_static/oralhistory/submasters/21198-zz002dx6rf-10-submaster.jpg', url = 'https://static.library.ucla.edu/oralhistory/submasters/21198-zz002dx6rf-10-submaster.jpg'
file_path = 'media_dev/oh_wowza/oralhistory/audio/submasters/21198-zz002dx6rf-10-submaster.mp3', url = 'https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/oralhistory/audio/submasters/21198-zz002dx6rf-10-submaster.mp3/playlist.m3u8'
file_path = 'media_dev/oh_wowza/oralhistory/audio/submasters/21198-zz002dx6rf-10-submaster.mp3', url = 'https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/oralhistory/audio/submasters/21198-zz002dx6rf-10-submaster.mp3/playlist.m3u8'
```
