### PR TITLE
SYS-892: Display file URLs (or paths) after processing

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.4
+  tag: v0.8.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -1,6 +1,7 @@
 import logging
 import mimetypes
 import os
+from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import F, Max
@@ -171,7 +172,7 @@ def get_related_file_group(media_type, target_file_use):
     return related_file_group
 
 
-def process_media_file(file_name, item_ark, file_group):
+def process_media_file(file_name, item_ark, file_group, request):
 
     try:
         media_type = calculate_media_type(file_name)
@@ -193,6 +194,8 @@ def process_media_file(file_name, item_ark, file_group):
 
         for content_file in content_file_data:
             update_db(content_file, item_ark)
+        # Add URL info for processed files to the request for later rendering.
+        messages.info(request, get_url_message(content_file_data))
 
     except AttributeError as ex:
         if media_type is None:
@@ -423,11 +426,14 @@ class Command(BaseCommand):
                             required=True, help='The full path of file to process')
         parser.add_argument('-g', '--file_group', type=str, required=True,
                             help='The file group of the file to process')
+        parser.add_argument('-r', '--request', required=False,
+                            help='The request from the view - do not use via command line')
 
     def handle(self, *args, **options):
         file_group = options['file_group']
         file_name = options['file_name']
         item_ark = options['item_ark']
+        request = options['request']
 
         # Log arguments, for now
         logger.info(f'\n\n===== Starting new run =====')
@@ -435,4 +441,4 @@ class Command(BaseCommand):
         logger.info(f'{file_name = }')
         logger.info(f'{item_ark = }')
 
-        process_media_file(file_name, item_ark, file_group)
+        process_media_file(file_name, item_ark, file_group, request)

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -400,6 +400,19 @@ def update_db(content_file_data, item_ark):
     content_file_data.divid_fk_id = project_item.pk
     content_file_data.save()
 
+
+def get_url_message(content_file_data):
+    # Builds HTML containing URL(s) for generated content files
+    html = '<ul>'
+    for content_file in content_file_data:
+        if content_file.file_location.startswith('http'):
+            html += f'<li><a href="{content_file.file_location}"">{content_file.file_use}</a></li>'
+        else:
+            html += f'<li>{content_file.file_use} = {content_file.file_location}</li>'
+    html += '</ul>'
+    return html
+
+
 class Command(BaseCommand):
     help = 'Django management command to process files'
 

--- a/oral_history/templates/oral_history/fileupload.html
+++ b/oral_history/templates/oral_history/fileupload.html
@@ -15,7 +15,7 @@ item_ark: {{ item.item_ark }}<br>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
           <span aria-hidden="True">&times;</span>
         </button>
-        {{ message }}
+        {{ message|safe }}
       </div>
     </div>
     {% endfor %}

--- a/oral_history/views.py
+++ b/oral_history/views.py
@@ -27,7 +27,7 @@ def upload_file(request):
 
             try:
                 call_command('process_file', file_group=file_group, file_name=file_name,
-                             item_ark=item_ark)
+                             item_ark=item_ark, request=request)
                 messages.success(
                     request, "The media file was successfully processed")
 


### PR DESCRIPTION
This PR enables the display of URLs (or paths, currently, for masters) for processed files.  A new message appears on the upload form after successful processing, listing the URLs/paths along with their `file_use` values (Master, Submaster, Thumbnail).

URLs don't display directly, but are hyperlinked via the `file_use` value.  Paths display in full.

The changes consist of:
* New function `get_url_message()` which builds the HTML from `content_file_data`
* New parameter to `process_file` so the view can pass the request needed by Django's messaging framework
* Addition of the `request` parameter where needed to pass it to other functions
* Bump image tag version to `v0.8.5`

Django's `messages` is effectively global, so does not need to be passed from the view to `process_file` to individual file processors.  Which is good, because management commands like `process_file` cannot return objects to their callers.

Testing: Use the UI to process various sample files and review the messages appearing for successful ones.  Example:

![url_path_message](https://user-images.githubusercontent.com/2213836/176796822-bc39df89-1862-4403-aad6-fc4c4da2c9c7.png)
