### PR TITLE
SYS-894: Handle file_sequence as integer

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.5
+  tag: v0.8.6
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
This PR fixes a bug calculating the `max` of `file_sequence`.  This data is numeric, but stored in the database (and model) as an un-normalized string, so does not automatically sort as a number.

This modified `get_next_seq_from_content_files()` to annotate with an `int_sequence` field which is an integer via Oracle's `to_number()` .  The query then aggregates on `max(int_sequence)` and returns that correctly-calculated value.

Also bumps image tag version to `v0.8.6`

Testing: Repeatedly process the same file in the UI and observe the `Master` filename as the sequence increments 9 -> 10 -> 11 etc.

Screenshot from http://127.0.0.1:8000/admin/oral_history/contentfiles/
![file_sequence_fixed](https://user-images.githubusercontent.com/2213836/176804845-77cb7baa-35c3-49d3-836b-822e5f6f9ee9.png)
