### PR TITLE
SYS-897: Improve template styling

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.6
+  tag: v0.8.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/templates/oral_history/base.html
+++ b/oral_history/templates/oral_history/base.html
@@ -2,13 +2,15 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <!-- Custom JS -->
-        <script src="{% static 'js/main.js' %}" defer></script>
-
         <!-- Include jquery and bootstrap - use versions compatible with each other -->
         <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+
+        <!-- Custom JS -->
+        <script src="{% static 'js/main.js' %}" defer></script>
+        <!-- Custom CSS -->
+        <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
     </head>
     <body>
         {% block content %}

--- a/oral_history/templates/oral_history/fileupload.html
+++ b/oral_history/templates/oral_history/fileupload.html
@@ -2,12 +2,14 @@
 
 {% block content %}
 Upload main media file for this item:<br>
-<br>
+<div class="box">
 {% for item in query_results %}
 {{ item.node_title }}<br>
 created_by: {{ item.created_by }}<br>
 item_ark: {{ item.item_ark }}<br>
 {% endfor %}
+</div>
+
 {% if messages %}
     {% for message in messages %}
     <div class="container-fluid p-0">
@@ -23,7 +25,9 @@ item_ark: {{ item.item_ark }}<br>
 <br>
 <form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="disable_upload_button(this);">
     {% csrf_token %}
-    {{ form.as_p }}
+    <table>
+    {{ form.as_table }}
+    </table>
     <button type="submit" id="upload_button">Upload</button>
 </form>
 {% endblock %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,10 @@
+body {
+	padding-left: 15px;
+	padding-top: 20px;
+}
+
+.box {
+	margin: 10px;
+	padding: 10px;
+	border: 1px solid black;
+}


### PR DESCRIPTION
This PR makes minor improvements to the visual appearance of `/table` and `/upload_file`:
* Page bodies are now top- and left-padded, instead of flush against those sides of the browser window
* Project item info on `/upload_file` is now in a box, with more padding & margin for visual distinction from the rest of the page
* Form elements on `/upload_file` are now in a table instead of using Django's `form.as_p`, reducing the space between elements.

Testing: Look at stuff.
