### PR TITLE
SYS-898: Fix static path/url problems

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.8.7
+  tag: v0.9.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -76,11 +76,12 @@ def get_app_folder_name():
     proj_app_name = getattr(Projects.objects.get(
         pk=PROJECT_ID), "webapp_name")
 
-    # Override for TEST environment only
+    # Override for TEST environment only;
+    # converts '/oralhistory' to '/oralhistory/oralhistory-test'
     if os.getenv('DJANGO_RUN_ENV') == 'test':
-        proj_app_name += '-test'
-    app_folder_name = f"/{proj_app_name}"
-    
+        proj_app_name += f'/{proj_app_name}-test'
+    app_folder_name = f'/{proj_app_name}'
+
     return app_folder_name
 
 def get_folder_by_use(file_use):

--- a/oral_history/scripts/audio_processor.py
+++ b/oral_history/scripts/audio_processor.py
@@ -84,8 +84,12 @@ class AudioProcessor():
         
         # Currently supported only for Submaster
         if self.file_use in ['Submaster']:
-            # Strip off first two elements of / delimited path, join the rest with /
-            url_path = '/'.join(file_path.split('/')[2:])
+            # Strip off mount-related elements of / delimited path, join the rest with /
+            # Local dev paths are relative (no initial /), test/prod paths are absolute (initial /)
+            if file_path.startswith('/'):
+                url_path = '/'.join(file_path.split('/')[3:])
+            else:
+                url_path = '/'.join(file_path.split('/')[2:])
             # Audio uses wowza, not static
             domain = 'https://wowza.library.ucla.edu'
             path_prefix = 'dlp/definst/mp3:oralhistory'

--- a/oral_history/scripts/file_processor.py
+++ b/oral_history/scripts/file_processor.py
@@ -74,8 +74,12 @@ class FileProcessor():
         
         # Currently supported only for Submaster and Thumbnail
         if self.file_use in ['Submaster', 'Thumbnail']:
-            # Strip off first two elements of / delimited path, join the rest with /
-            url_path = '/'.join(file_path.split('/')[2:])
+            # Strip off mount-related elements of / delimited path, join the rest with /
+            # Local dev paths are relative (no initial /), test/prod paths are absolute (initial /)
+            if file_path.startswith('/'):
+                url_path = '/'.join(file_path.split('/')[3:])
+            else:
+                url_path = '/'.join(file_path.split('/')[2:])
             domain = 'https://static.library.ucla.edu'
             url = f'{domain}/{url_path}'
             logger.info(f'{file_path = }, {url = }')

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -89,8 +89,12 @@ class ImageProcessor():
 
         # Currently supported only for Submaster and Thumbnail
         if image_category in [ImageProcessor.SUBMASTER_CATEGORY, ImageProcessor.THUMBNAIL_CATEGORY]:
-            # Strip off first two elements of / delimited path, join the rest with /
-            url_path = '/'.join(file_path.split('/')[2:])
+            # Strip off mount-related elements of / delimited path, join the rest with /
+            # Local dev paths are relative (no initial /), test/prod paths are absolute (initial /)
+            if file_path.startswith('/'):
+                url_path = '/'.join(file_path.split('/')[3:])
+            else:
+                url_path = '/'.join(file_path.split('/')[2:])
             domain = 'https://static.library.ucla.edu'
             url = f'{domain}/{url_path}'
             logger.info(f'{file_path = }, {url = }')


### PR DESCRIPTION
This PR fixes two problems with static paths and URLs:
* Update processor `get_url()` functions to distinguish between relative and absolute paths
* Update `process_file.get_app_folder_name()` to use nested folder instead of parallel folder for `test` environment
Bumps image tag to `v0.9.0`

Tested in a bash shell on the container (necessary for python to have the right environment).  In `dev` and `prod` environments the app folder is `/oralhistory`;  in `test` environment, `/oralhistory/oralhistory-test`.

```
django@b8f662118b75:~/dlcs-staff-ui$ export DJANGO_RUN_ENV=dev
django@b8f662118b75:~/dlcs-staff-ui$ python manage.py shell
>>> import oral_history.management.commands.process_file as pf; pf.get_app_folder_name()
'/oralhistory'

django@b8f662118b75:~/dlcs-staff-ui$ export DJANGO_RUN_ENV=test
django@b8f662118b75:~/dlcs-staff-ui$ python manage.py shell
>>> import oral_history.management.commands.process_file as pf; pf.get_app_folder_name()
'/oralhistory/oralhistory-test'

django@b8f662118b75:~/dlcs-staff-ui$ export DJANGO_RUN_ENV=prod
django@b8f662118b75:~/dlcs-staff-ui$ python manage.py shell
>>> import oral_history.management.commands.process_file as pf; pf.get_app_folder_name()
'/oralhistory'
```

