### PR TITLE
SYS-912: Add 'use_test_dirs' variable, and point application to production

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -28,6 +28,11 @@ DJANGO_DLCS_FILE_SOURCE=samples
 # Or absolute path, if preferred
 #DJANGO_DLCS_FILE_SOURCE=/home/django/dlcs-staff-ui/samples
 
+# Use "test" directories?  Was based on DJANGO_RUN_ENV but can't use that
+# when in production on test k8s environment.
+# Use "Yes" and "No" here.
+DJANGO_USE_TEST_DIRS=No
+
 # Various media directories for processed files
 # Relative paths for development, absolute for real mounts
 # Oral History source files

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for DLCS Staff UI
 name: dlcs-staff-ui
-version: 0.6.1
+version: 0.6.5

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -17,3 +17,4 @@ data:
   DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
   DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
   DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}
+  DJANGO_USE_TEST_DIRS: {{ .Values.django.env.use_test_dirs }}

--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v0.9.0
+  tag: v1.0.0
   pullPolicy: Always
 
 nameOverride: ""
@@ -42,7 +42,8 @@ django:
     log_level: "INFO"
     allowed_hosts:
       - dlcs-staff.library.ucla.edu
-    db_dsn: "dba-lib-odb-q01.it.ucla.edu:1521/DLCS"
+    # Now pointing to production db, from test k8s environment
+    db_dsn: "dba-lib-odb-p01.it.ucla.edu:1521/DLCS"
     db_user: "dlcs"
     # Specific directory used for source files
     dlcs_file_source: "/media/oh_source/upload"
@@ -50,6 +51,8 @@ django:
     oh_masterslz: "/media/oh_lz"
     oh_static: "/media/oh_static"
     oh_wowza: "/media/oh_wowza"
+    # "Yes" or "No"
+    use_test_dirs: "No"
 
   externalSecrets:
     enabled: "true"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -48,6 +48,7 @@ django:
     oh_masterslz: ""
     oh_static: ""
     oh_wowza: ""
+    use_test_dirs: ""
 
   externalSecrets:
     enabled: "false"

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -76,9 +76,10 @@ def get_app_folder_name():
     proj_app_name = getattr(Projects.objects.get(
         pk=PROJECT_ID), "webapp_name")
 
-    # Override for TEST environment only;
+    # Override used in real TEST environment only;
     # converts '/oralhistory' to '/oralhistory/oralhistory-test'
-    if os.getenv('DJANGO_RUN_ENV') == 'test':
+    # Can't use DJANGO_RUN_ENV when in production on test k8s environment.
+    if os.getenv('DJANGO_USE_TEST_DIRS') == 'Yes':
         proj_app_name += f'/{proj_app_name}-test'
     app_folder_name = f'/{proj_app_name}'
 


### PR DESCRIPTION
This PR adds a `use_test_dirs` variable, to separate that functionality from the environment the application is running in.
It also points the application to the production database.
Chart version and image tag versions have been updated.

@sgurnick Please review the chart changes to be sure I didn't miss anything.
@kjallen Please review the code changes (trivial, but still...).  I tested locally by updating `DJANGO_USE_TEST_DIRS` in `.docker_compose_django.env` and restarting the application.