### PR TITLE
Sys 925/static path fix

### DIFF
--- a/charts/test-dlcsstaffui-values.yaml
+++ b/charts/test-dlcsstaffui-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/dlcs-staff-ui
-  tag: v1.0.0
+  tag: v1.0.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -80,7 +80,7 @@ def get_app_folder_name():
         pk=PROJECT_ID), "webapp_name")
 
     # Override used in real TEST environment only;
-    # converts '/oralhistory' to '/oralhistory/oralhistory-test'
+    # converts a proj_app_name of '/oralhistory' to '/oralhistory-test' to designate test usage
     # Can't use DJANGO_RUN_ENV when in production on test k8s environment.
     if os.getenv('DJANGO_USE_TEST_DIRS') == 'Yes':
         proj_app_name = f'/{proj_app_name}-test'

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -37,7 +37,10 @@ def calculate_destination_dir(media_type, item_ark, file_use):
 
         logger.info(f"{local_root = }, {app_folder = }, {media_folder =}")
     
-        full_dest_dir = f"{local_root}{app_folder}{media_folder}"
+        if os.getenv('DJANGO_USE_TEST_DIRS') == 'Yes':
+            full_dest_dir = f"{local_root}{app_folder}{media_folder}"
+        else:
+            full_dest_dir = f"{local_root}{media_folder}"
 
         return full_dest_dir 
     

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -83,9 +83,9 @@ def get_app_folder_name():
     # converts a proj_app_name of '/oralhistory' to '/oralhistory-test' to designate test usage
     # Can't use DJANGO_RUN_ENV when in production on test k8s environment.
     if os.getenv('DJANGO_USE_TEST_DIRS') == 'Yes':
-        proj_app_name = f'/{proj_app_name}-test'
+        proj_app_name = f'{proj_app_name}-test'
     app_folder_name = f'/{proj_app_name}'
-
+    
     return app_folder_name
 
 def get_folder_by_use(file_use):

--- a/oral_history/management/commands/process_file.py
+++ b/oral_history/management/commands/process_file.py
@@ -83,7 +83,7 @@ def get_app_folder_name():
     # converts '/oralhistory' to '/oralhistory/oralhistory-test'
     # Can't use DJANGO_RUN_ENV when in production on test k8s environment.
     if os.getenv('DJANGO_USE_TEST_DIRS') == 'Yes':
-        proj_app_name += f'/{proj_app_name}-test'
+        proj_app_name = f'/{proj_app_name}-test'
     app_folder_name = f'/{proj_app_name}'
 
     return app_folder_name

--- a/oral_history/scripts/file_processor.py
+++ b/oral_history/scripts/file_processor.py
@@ -80,7 +80,7 @@ class FileProcessor():
                 url_path = '/'.join(file_path.split('/')[3:])
             else:
                 url_path = '/'.join(file_path.split('/')[2:])
-            domain = 'https://static.library.ucla.edu'
+            domain = 'https://static.library.ucla.edu/oralhistory'
             url = f'{domain}/{url_path}'
             logger.info(f'{file_path = }, {url = }')
             return url

--- a/oral_history/scripts/image_processor.py
+++ b/oral_history/scripts/image_processor.py
@@ -95,7 +95,7 @@ class ImageProcessor():
                 url_path = '/'.join(file_path.split('/')[3:])
             else:
                 url_path = '/'.join(file_path.split('/')[2:])
-            domain = 'https://static.library.ucla.edu'
+            domain = 'https://static.library.ucla.edu/oralhistory'
             url = f'{domain}/{url_path}'
             logger.info(f'{file_path = }, {url = }')
             return url


### PR DESCRIPTION
Some tweaks to how the folders are created --
Assumptions : All mount points end with an oralhistory folder (or in the case of masters, designated oralhistory)

If `DJANGO_USE_TEST_DIRS` is *not* set, ignore the app_folder name altogether. This is the case for production.

If `DJANGO_USE_TEST_DIRS` *is* set, use only the `webappname + test` as the folder, rather than `webappname/webappname+test`

Update file and image script `get_url` method url stub to include `/oralhistory`